### PR TITLE
Avoid internal references to 'cgal' as a node module name

### DIFF
--- a/test/Arrangement2.spec.js
+++ b/test/Arrangement2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.Arrangement2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     var l1, l2, l3, arr;
 

--- a/test/BBox2.spec.js
+++ b/test/BBox2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.BBox2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it("should be constructable from limits", function() {
         expect(function() { return new CGAL.BBox2({xmin:1, ymin:2, xmax:3, ymax:4}); }).not.toThrow();

--- a/test/D2.spec.js
+++ b/test/D2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.convexPartition2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it("should convexify a concave poly", function() {
         var result = CGAL.convexPartition2([[0,0],[5,5],[10,0],[10,10],[0,10]]);
@@ -35,7 +35,7 @@ describe("CGAL.convexPartition2", function() {
 describe("CGAL.convexHull2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it("should convexify a set of points", function() {
         var result = CGAL.convexHull2([[0,0],[5,5],[10,0],[10,10],[0,10]]);
@@ -62,7 +62,7 @@ describe("CGAL.convexHull2", function() {
 describe("CGAL.doIntersect", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     var poly1 = new CGAL.Polygon2([[0,0],[4,0],[0,4]]);
     var poly2 = new CGAL.Polygon2([[0,0],[4,4],[0,4]]);

--- a/test/Line2.spec.js
+++ b/test/Line2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.Line2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it("should be constructable from coefficients", function() {
         expect(function() { return new CGAL.Line2({a:1, b:2, c:3}); }).not.toThrow();

--- a/test/NefPolyhedron2.spec.js
+++ b/test/NefPolyhedron2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.NefPolyhedron2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it ("should pass vacuous unit test", function() {
         expect(true).toBeTruthy();

--- a/test/Point2.spec.js
+++ b/test/Point2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.Point2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it("should be constructable from an array", function() {
         expect(function() { return new CGAL.Point2([0,0]); }).not.toThrow();

--- a/test/Polygon2.spec.js
+++ b/test/Polygon2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.Polygon2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it("should be constructable from an array of points", function() {
         expect(function() { return new CGAL.Polygon2([[0,0], [1,1], [0,2]]); }).not.toThrow();

--- a/test/PolygonSet2.spec.js
+++ b/test/PolygonSet2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.PolygontSet2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it("should be constructable with no args, Polygon2, or PolygonWithHoles2", function() {
         var p2 = new CGAL.Polygon2([[0,0],[1,0],[1,1],[0,1]]);

--- a/test/PolygonWithHoles2.spec.js
+++ b/test/PolygonWithHoles2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.PolygonWithHoles2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it("should be constructable from an object with arrays of points", function() {
         expect(function() { return new CGAL.PolygonWithHoles2({outer:[[0,0], [1,1], [0,2]], holes: []}); }).not.toThrow();

--- a/test/Segment2.spec.js
+++ b/test/Segment2.spec.js
@@ -1,7 +1,7 @@
 describe("CGAL.Segment2", function() {
     'use strict';
 
-    var CGAL = require('cgal');
+    var CGAL = require('..');
 
     it("should be constructable from two points", function() {
         expect(function() { return new CGAL.Segment2({source:[0,0], target:[1,1]}); }).not.toThrow();


### PR DESCRIPTION
Use relative internal paths instead. This allows the unit tests to pass
in a vanilla node environment.
