### PR TITLE
Avoid unnecessary node-gyp clean on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "jasmine-node-karma": "1.6.1"
   },
   "scripts": {
-    "test": "scripts/test"
+    "test": "scripts/test",
+    "preinstall": "node-gyp configure && node-gyp build",
+    "clean": "node-gyp clean && rm -rf build"
   },
   "engines": {
     "node": ">=0.10.7"


### PR DESCRIPTION
Building this module takes forever, so we really don't want to clean
unless it's necessary. Avoiding `node-gyp rebuild` that is defaulted to
the preinstall script and instead invoking the configure and build phases
explicitly. Adding a 'clean' script to this package that will invoke
`node-gyp clean`
