### PR TITLE
Hackathon squash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /node_modules
 /build
-/CGAL-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ env:
   global:
     CGAL_GYP_LDFLAGS: -L$TRAVIS_BUILD_DIR/CGAL-4.4/lib
     CGAL_GYP_INCLUDES: $TRAVIS_BUILD_DIR/CGAL-4.4/include
+  matrix:
+    -
+    - GGAL_USE_EPECK=1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-cgal
 =========
 
-[![Build Status](https://travis-ci.org/Vannevartech/cgal.png?branch=master)](https://travis-ci.org/Vannevartech/cgal)
+[![Build Status](https://travis-ci.org/fritzm.org/cgal.png?branch=master)](https://travis-ci.org/fritzm.org/cgal)
 
 A node.js module providing access to parts of the CGAL computational geometry library (non-SWIG).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-cgal
 =========
 
-[![Build Status](https://travis-ci.org/fritzm.org/cgal.png?branch=master)](https://travis-ci.org/fritzm.org/cgal)
+[![Build Status](https://travis-ci.org/fritzm/node-cgal.png?branch=master)](https://travis-ci.org/fritzm/node-cgal)
 
 A node.js module providing access to parts of the CGAL computational geometry library (non-SWIG).
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,7 @@
 
         'sources': [
             'src/cgal.cc',
+            'src/AffTransformation2.cc',
             'src/Arrangement2.cc',
             'src/Arrangement2Face.cc',
             'src/Arrangement2Halfedge.cc',
@@ -35,6 +36,8 @@
                     'GCC_ENABLE_CPP_RTTI': 'YES',
                     'OTHER_CPLUSPLUSFLAGS': [
                         '-Wno-unneeded-internal-declaration',
+                        '-mmacosx-version-min=10.7',
+                        '-stdlib=libc++',
                         '<!@(echo $CGAL_GYP_CXXFLAGS)'
                      ],
                     'OTHER_LDFLAGS': [ '<!@(echo $CGAL_GYP_LDFLAGS)' ]

--- a/src/AffTransformation2.cc
+++ b/src/AffTransformation2.cc
@@ -1,0 +1,149 @@
+#include "AffTransformation2.h"
+#include "Direction2.h"
+#include "cgal_args.h"
+
+using namespace v8;
+using namespace node;
+using namespace std;
+
+
+const char *AffTransformation2::Name = "AffTransformation2";
+
+
+void AffTransformation2::RegisterMethods()
+{
+}
+
+
+bool AffTransformation2::ParseArg(Local<Value> arg, Aff_transformation_2 &receiver)
+{
+    if (sConstructorTemplate->HasInstance(arg)) {
+
+        receiver = ExtractWrapped(Local<Object>::Cast(arg));
+        return true;
+
+    } else if (arg->IsArray()) {
+
+        Local<Array> coords = Local<Array>::Cast(arg);
+        if (coords->Length() >= 6 && coords->Length() <= 7) {
+
+            if (coords->Get(0)->IsNumber() && coords->Get(1)->IsNumber() &&
+                coords->Get(2)->IsNumber() && coords->Get(3)->IsNumber() &&
+                coords->Get(4)->IsNumber() && coords->Get(5)->IsNumber() &&
+                (coords->Length() == 6 || coords->Get(6)->IsNumber())) {
+
+                K::RT hw(1);
+                if (coords->Length() == 7)
+                    hw = K::RT(coords->Get(6)->NumberValue());
+
+                K::RT m00(coords->Get(0)->NumberValue());
+                K::RT m01(coords->Get(1)->NumberValue());
+                K::RT m02(coords->Get(2)->NumberValue());
+                K::RT m10(coords->Get(3)->NumberValue());
+                K::RT m11(coords->Get(4)->NumberValue());
+                K::RT m12(coords->Get(5)->NumberValue());
+
+                receiver = Aff_transformation_2(m00, m01, m02, m10, m11, m12, hw);
+                return true;
+
+            } else if (coords->Get(0)->IsString() && coords->Get(1)->IsString() &&
+                coords->Get(2)->IsString() && coords->Get(3)->IsString() &&
+                coords->Get(4)->IsString() && coords->Get(5)->IsString() &&
+                (coords->Length() == 6 || coords->Get(6)->IsString())) {
+
+                K::RT hw(1);
+
+#ifdef CGAL_USE_EPECK
+
+                if (coords->Length() == 7)
+                    hw = K::RT(CGAL::Epeck_ft(*String::AsciiValue(coords->Get(6))));
+
+                K::RT m00(CGAL::Epeck_ft(*String::AsciiValue(coords->Get(0))));
+                K::RT m01(CGAL::Epeck_ft(*String::AsciiValue(coords->Get(1))));
+                K::RT m02(CGAL::Epeck_ft(*String::AsciiValue(coords->Get(2))));
+                K::RT m10(CGAL::Epeck_ft(*String::AsciiValue(coords->Get(3))));
+                K::RT m11(CGAL::Epeck_ft(*String::AsciiValue(coords->Get(4))));
+                K::RT m12(CGAL::Epeck_ft(*String::AsciiValue(coords->Get(5))));
+
+#else // !defined(CGAL_USE_EPECK)
+
+                if (coords->Length() == 7)
+                    hw = K::RT(atof(*String::AsciiValue(coords->Get(6))));
+
+                K::RT m00(atof(*String::AsciiValue(coords->Get(0))));
+                K::RT m01(atof(*String::AsciiValue(coords->Get(1))));
+                K::RT m02(atof(*String::AsciiValue(coords->Get(2))));
+                K::RT m10(atof(*String::AsciiValue(coords->Get(3))));
+                K::RT m11(atof(*String::AsciiValue(coords->Get(4))));
+                K::RT m12(atof(*String::AsciiValue(coords->Get(5))));
+
+#endif // !defined(CGAL_USE_EPECK)
+
+                receiver = Aff_transformation_2(m00, m01, m02, m10, m11, m12, hw);
+                return true;
+
+            } else {
+                return false;
+            }
+
+        } else if (coords->Length() == 2 || coords->Length() == 3) {
+
+            Direction_2 dir;
+            if (Direction2::ParseArg(coords->Get(0), dir) && coords->Get(1)->IsNumber()
+                && (coords->Length() == 2 || coords->Get(2)->IsNumber())) {
+
+                K::RT den(1);
+                if (coords->Length() == 3)
+                    den = K::RT(coords->Get(2)->NumberValue());
+
+                K::RT num(coords->Get(1)->NumberValue());
+
+                receiver = Aff_transformation_2(Rotation(), dir, num, den);
+                return true;
+
+            } else {
+                return false;
+            }
+
+        } else {
+            return false;
+        }
+
+    } else {
+        return false;
+    }
+
+}
+
+
+Handle<Value> AffTransformation2::ToPOD(const Aff_transformation_2 &aff, bool precise)
+{
+    HandleScope scope;
+    Local<Array> array = Array::New(7);
+
+    try {
+        for(int i=0; i<7; ++i) {
+            int r = (i == 6) ? 2 : i/3;
+            int c = (i == 6) ? 2 : i%3;
+            K::RT a = aff.hm(r, c);
+            if (precise) {
+                ostringstream str;
+#ifdef CGAL_USE_EPECK
+                str << a.exact();
+#else
+                str << a;
+#endif
+                array->Set(i, String::New(str.str().c_str()));
+            } else {
+                array->Set(i, Number::New(CGAL::to_double(a)));
+            }
+        }
+    }
+
+    catch (const exception &e) {
+        return ThrowException(String::New(e.what()));
+    }
+
+    return scope.Close(array);
+}
+

--- a/src/AffTransformation2.h
+++ b/src/AffTransformation2.h
@@ -1,12 +1,12 @@
-#ifndef POINT2_H
-#define POINT2_H
+#ifndef AFFTRANSFORMATION2_H
+#define AFFTRANSFORMATION2_H
 
 #include "CGALWrapper.h"
 #include "cgal_types.h"
 #include "v8.h"
 
 
-class Point2 : public CGALWrapper<Point2, Point_2>
+class AffTransformation2 : public CGALWrapper<AffTransformation2, Aff_transformation_2>
 {
 public:
 
@@ -20,25 +20,19 @@ public:
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Point_2 &receiver);
+    static bool ParseArg(v8::Local<v8::Value> arg, Aff_transformation_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Point_2 &point, bool precise=true);
+    static v8::Handle<v8::Value> ToPOD(const Aff_transformation_2 &aff, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Point_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
-
-    static v8::Handle<v8::Value> ToString(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);
-    static v8::Handle<v8::Value> X(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Y(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Transform(const v8::Arguments &args);
 
 };
 
-#endif // !defined(POINT2_H)
+#endif // !defined(AFFTRANSFORMATION2_H)

--- a/src/Arrangement2.cc
+++ b/src/Arrangement2.cc
@@ -72,7 +72,7 @@ bool Arrangement2::ParseArg(Local<Value> arg, Arrangement_2 &receiver)
 }
 
 
-Handle<Value> Arrangement2::ToPOD(const Arrangement_2 &arrangement)
+Handle<Value> Arrangement2::ToPOD(const Arrangement_2 &arrangement, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();
@@ -101,7 +101,7 @@ Handle<Value> Arrangement2::ToPOD(const Arrangement_2 &arrangement)
             do { *bit++  = curr->source()->point(); } while (++curr != circ);
 
             // Add poly created from edge source points to face array.
-            faceArray->Set(faceNum, Polygon2::ToPOD(poly));
+            faceArray->Set(faceNum, Polygon2::ToPOD(poly, precise));
             faceNum++;
         }
     }
@@ -457,7 +457,7 @@ Handle<Value> Arrangement2::InsertInFaceInterior(const v8::Arguments &args)
             && Curve2::ParseArg(args[0], curve)
             && Arrangement2Face::ParseArg(args[1], face))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_in_face_interior(curve, face)));            
+            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_in_face_interior(curve, face)));
         }
 
         ARGS_ASSERT(false);
@@ -500,7 +500,7 @@ Handle<Value> Arrangement2::InsertFromLeftVertex(const v8::Arguments &args)
             && Curve2::ParseArg(args[0], curve)
             && Arrangement2Halfedge::ParseArg(args[1], edge))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_left_vertex(curve, edge)));            
+            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_left_vertex(curve, edge)));
         }
 
         ARGS_ASSERT(false);
@@ -543,7 +543,7 @@ Handle<Value> Arrangement2::InsertFromRightVertex(const v8::Arguments &args)
             && Curve2::ParseArg(args[0], curve)
             && Arrangement2Halfedge::ParseArg(args[1], edge))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_right_vertex(curve, edge)));            
+            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_right_vertex(curve, edge)));
         }
 
         ARGS_ASSERT(false);
@@ -617,7 +617,7 @@ Handle<Value> Arrangement2::ModifyVertex(const v8::Arguments &args)
         ARGS_ASSERT(args.Length() == 2);
         ARGS_PARSE_LOCAL(Arrangement2Vertex::ParseArg, Arrangement_2::Vertex_handle, vertex, args[0]);
         ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, point, args[1]);
-        return scope.Close(Arrangement2Vertex::New(arrangement.modify_vertex(vertex, point)));            
+        return scope.Close(Arrangement2Vertex::New(arrangement.modify_vertex(vertex, point)));
     }
     catch (const exception &e) {
         return ThrowException(String::New(e.what()));
@@ -632,7 +632,7 @@ Handle<Value> Arrangement2::RemoveIsolatedVertex(const v8::Arguments &args)
         Arrangement_2 &arrangement = ExtractWrapped(args.This());
         ARGS_ASSERT(args.Length() == 1);
         ARGS_PARSE_LOCAL(Arrangement2Vertex::ParseArg, Arrangement_2::Vertex_handle, vertex, args[0]);
-        return scope.Close(Arrangement2Face::New(arrangement.remove_isolated_vertex(vertex)));            
+        return scope.Close(Arrangement2Face::New(arrangement.remove_isolated_vertex(vertex)));
     }
     catch (const exception &e) {
         return ThrowException(String::New(e.what()));
@@ -648,7 +648,7 @@ Handle<Value> Arrangement2::ModifyEdge(const v8::Arguments &args)
         ARGS_ASSERT(args.Length() == 2);
         ARGS_PARSE_LOCAL(Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge, args[0]);
         ARGS_PARSE_LOCAL(Curve2::ParseArg, Curve_2, curve, args[1]);
-        return scope.Close(Arrangement2Halfedge::New(arrangement.modify_edge(halfedge, curve)));            
+        return scope.Close(Arrangement2Halfedge::New(arrangement.modify_edge(halfedge, curve)));
     }
     catch (const exception &e) {
         return ThrowException(String::New(e.what()));
@@ -665,7 +665,7 @@ Handle<Value> Arrangement2::SplitEdge(const v8::Arguments &args)
         ARGS_PARSE_LOCAL(Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge, args[0]);
         ARGS_PARSE_LOCAL(Curve2::ParseArg, Curve_2, curve1, args[1]);
         ARGS_PARSE_LOCAL(Curve2::ParseArg, Curve_2, curve2, args[2]);
-        return scope.Close(Arrangement2Halfedge::New(arrangement.split_edge(halfedge, curve1, curve2)));            
+        return scope.Close(Arrangement2Halfedge::New(arrangement.split_edge(halfedge, curve1, curve2)));
     }
     catch (const exception &e) {
         return ThrowException(String::New(e.what()));
@@ -682,7 +682,7 @@ Handle<Value> Arrangement2::MergeEdge(const v8::Arguments &args)
         ARGS_PARSE_LOCAL(Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge1, args[0]);
         ARGS_PARSE_LOCAL(Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge2, args[1]);
         ARGS_PARSE_LOCAL(Curve2::ParseArg, Curve_2, curve, args[2]);
-        return scope.Close(Arrangement2Halfedge::New(arrangement.merge_edge(halfedge1, halfedge2, curve)));            
+        return scope.Close(Arrangement2Halfedge::New(arrangement.merge_edge(halfedge1, halfedge2, curve)));
     }
     catch (const exception &e) {
         return ThrowException(String::New(e.what()));
@@ -698,7 +698,7 @@ Handle<Value> Arrangement2::RemoveEdge(const v8::Arguments &args)
         Arrangement_2 &arrangement = ExtractWrapped(args.This());
 
         Arrangement_2::Halfedge_handle edge;
- 
+
         if ((args.Length() == 1)
             && Arrangement2Halfedge::ParseArg(args[0], edge))
         {

--- a/src/Arrangement2.h
+++ b/src/Arrangement2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Arrangement_2 class
-
 class Arrangement2 : public CGALWrapper<Arrangement2, Arrangement_2>
 {
 public:
@@ -20,21 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 argument into the CGAL Arrangement_2 object referred to
-    // by receiver.  Accepts either an Arrangement2 JS object or an array of any two things that are
-    // or can be constructed into Point2 objects (taken as start and end points of Arrangement).
-    // Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Arrangement_2 &receiver);
 
-    // Convert a CGAL::Arrangement_2 object to a POD v8 object.  This renders a Arrangement to
-    // an array of arrays of two doubles (start and end point coords), and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Arrangement_2 &Arrangement);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Arrangement_2 &Arrangement, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Arrangement_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
     static v8::Handle<v8::Value> ToString(const v8::Arguments &args);

--- a/src/Arrangement2Face.cc
+++ b/src/Arrangement2Face.cc
@@ -39,7 +39,7 @@ bool Arrangement2Face::ParseArg(Local<Value> arg, Arrangement_2::Face_handle &re
 }
 
 
-Handle<Value> Arrangement2Face::ToPOD(const Arrangement_2::Face_handle &face)
+Handle<Value> Arrangement2Face::ToPOD(const Arrangement_2::Face_handle &face, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();
@@ -53,7 +53,7 @@ Handle<Value> Arrangement2Face::ToString(const v8::Arguments &args)
     Arrangement_2::Face_handle &face = ExtractWrapped(args.This());
     ostringstream str;
     str << "[object "  << Name << " " << face.ptr() << " ";
-    if (face->is_fictitious()) { 
+    if (face->is_fictitious()) {
         str << "FIC ";
     } else if (face->is_unbounded()) {
         str << "UNB ";
@@ -114,7 +114,7 @@ Handle<Value> Arrangement2Face::OuterCCB(const v8::Arguments &args)
             first = curr = face->outer_ccb();
             uint32_t i = 0;
             do {
-                array->Set(i, Arrangement2Halfedge::New(curr));                
+                array->Set(i, Arrangement2Halfedge::New(curr));
             } while(++i,++curr != first);
         }
         return scope.Close(array);
@@ -140,7 +140,7 @@ Handle<Value> Arrangement2Face::Holes(const v8::Arguments &args)
             first = curr = *it;
             uint32_t j = 0;
             do {
-                hole->Set(j, Arrangement2Halfedge::New(curr));                
+                hole->Set(j, Arrangement2Halfedge::New(curr));
             } while(++j,++curr != first);
         }
         return scope.Close(array);

--- a/src/Arrangement2Face.h
+++ b/src/Arrangement2Face.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Arrangement_2::Face_handle class
-
 class Arrangement2Face : public CGALWrapper<Arrangement2Face, Arrangement_2::Face_handle>
 {
 public:
@@ -20,20 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 argument into the CGAL Arrangement_2::Face_handle object referred to
-    // by receiver.  Accepts either an Arrangement2.Face JS object or ...
-    // Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Arrangement_2::Face_handle &receiver);
 
-    // Convert a CGAL::Arrangement_2::Face_handle object to a POD v8 object.  This renders an
-    // face handle as ... and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Arrangement_2::Face_handle &face);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Arrangement_2::Face_handle &face, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Arrangement_2::Face methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
     static v8::Handle<v8::Value> ToString(const v8::Arguments &args);

--- a/src/Arrangement2Halfedge.cc
+++ b/src/Arrangement2Halfedge.cc
@@ -44,7 +44,7 @@ bool Arrangement2Halfedge::ParseArg(Local<Value> arg, Arrangement_2::Halfedge_ha
 }
 
 
-Handle<Value> Arrangement2Halfedge::ToPOD(const Arrangement_2::Halfedge_handle &halfedge)
+Handle<Value> Arrangement2Halfedge::ToPOD(const Arrangement_2::Halfedge_handle &halfedge, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();
@@ -58,9 +58,9 @@ Handle<Value> Arrangement2Halfedge::ToString(const v8::Arguments &args)
     Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
     ostringstream str;
     str << "[object "  << Name << " " << edge.ptr() << " ";
-    if (edge->is_fictitious()) { 
+    if (edge->is_fictitious()) {
         str << "FIC ";
-    } 
+    }
     str << "]";
     return scope.Close(String::New(str.str().c_str()));
 }
@@ -167,7 +167,7 @@ Handle<Value> Arrangement2Halfedge::CCB(const v8::Arguments &args)
         first = curr = edge->ccb();
         uint32_t i = 0;
         do {
-            array->Set(i, Arrangement2Halfedge::New(curr));                
+            array->Set(i, Arrangement2Halfedge::New(curr));
         } while(++i,++curr != first);
         return scope.Close(array);
     }

--- a/src/Arrangement2Halfedge.h
+++ b/src/Arrangement2Halfedge.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Arrangement_2::Halfedge_handle class
-
 class Arrangement2Halfedge : public CGALWrapper<Arrangement2Halfedge, Arrangement_2::Halfedge_handle>
 {
 public:
@@ -20,20 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 argument into the CGAL Arrangement_2::Halfedge_handle object referred 
-    // to by receiver.  Accepts either an Arrangement2.Halfedge JS object or ...
-    // Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Arrangement_2::Halfedge_handle &receiver);
 
-    // Convert a CGAL::Arrangement_2::Halfedge_handle object to a POD v8 object.  This renders a
-    // halfedge handle as ... and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Arrangement_2::Halfedge_handle &halfedge);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Arrangement_2::Halfedge_handle &halfedge, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Arrangement_2::Halfedge methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
     static v8::Handle<v8::Value> ToString(const v8::Arguments &args);

--- a/src/Arrangement2Vertex.cc
+++ b/src/Arrangement2Vertex.cc
@@ -44,7 +44,7 @@ bool Arrangement2Vertex::ParseArg(Local<Value> arg, Arrangement_2::Vertex_handle
 }
 
 
-Handle<Value> Arrangement2Vertex::ToPOD(const Arrangement_2::Vertex_handle &vertex)
+Handle<Value> Arrangement2Vertex::ToPOD(const Arrangement_2::Vertex_handle &vertex, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();
@@ -83,7 +83,7 @@ Handle<Value> Arrangement2Vertex::ToString(const v8::Arguments &args)
             break;
         }
     } else {
-        str << vertex->point(); 
+        str << vertex->point();
     }
     str << "]";
     return scope.Close(String::New(str.str().c_str()));
@@ -139,7 +139,7 @@ Handle<Value> Arrangement2Vertex::IncidentHalfedges(const v8::Arguments &args)
         first = curr = vertex->incident_halfedges();
         uint32_t i = 0;
         do {
-            array->Set(i, Arrangement2Halfedge::New(curr));                
+            array->Set(i, Arrangement2Halfedge::New(curr));
         } while(++i,++curr != first);
         return scope.Close(array);
     }

--- a/src/Arrangement2Vertex.h
+++ b/src/Arrangement2Vertex.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Arrangement_2::Vertex_handle class
-
 class Arrangement2Vertex : public CGALWrapper<Arrangement2Vertex, Arrangement_2::Vertex_handle>
 {
 public:
@@ -20,20 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 argument into the CGAL Arrangement_2 object referred to
-    // by receiver.  Accepts either an Arrangement2.Vertex_handle JS object or ...
-    // Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Arrangement_2::Vertex_handle &receiver);
 
-    // Convert a CGAL::Arrangement_2::Vertex_handle object to a POD v8 object.  This renders a 
-    // vertex handle as ... and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Arrangement_2::Vertex_handle &Vertex);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Arrangement_2::Vertex_handle &Vertex, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Arrangement_2::Vertex methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
     static v8::Handle<v8::Value> ToString(const v8::Arguments &args);

--- a/src/BBox2.cc
+++ b/src/BBox2.cc
@@ -20,14 +20,10 @@ bool BBox2::ParseArg(Local<Value> arg, Bbox_2 &receiver)
 {
     if (sConstructorTemplate->HasInstance(arg)) {
 
-        // This supports e.g.: newbox = new CGAL.BBox2(oldbox);
-
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
 
     } else if (arg->IsObject()) {
-
-        // This supports e.g.: newbox = new CGAL.BBox2({xmin:,ymin:,xmax:,ymax:});
 
         Local<Object> bounds = Local<Object>::Cast(arg);
 
@@ -56,7 +52,7 @@ bool BBox2::ParseArg(Local<Value> arg, Bbox_2 &receiver)
 }
 
 
-Handle<Value> BBox2::ToPOD(const Bbox_2 &box)
+Handle<Value> BBox2::ToPOD(const Bbox_2 &box, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();

--- a/src/BBox2.h
+++ b/src/BBox2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Bbox_2 class
-
 class BBox2 : public CGALWrapper<BBox2, Bbox_2>
 {
 public:
@@ -20,26 +18,22 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 object into the CGAL Bbox_2 object referred to by receiver.  Accepts
-    // either a BBox2 object or a POD rep {xmin:,ymin:,xmax:,ymax:}.  Returns true if parse was
-    // successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Bbox_2 &receiver);
 
-    // Convert a CGAL::BBox_2 object to a POD v8 object of the form  {xmin:,ymin:,xmax:,ymax:}.
-    // This may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Bbox_2 &box);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Bbox_2 &box, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::BBox_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
-    // Returns true if this bbox overlaps with the bbox argument.
     static v8::Handle<v8::Value> Overlaps(const v8::Arguments &args);
-
-    // Returns the smallest bbox that contains both this bbox and the bbox arguemnt.
     static v8::Handle<v8::Value> Add(const v8::Arguments &args);
 
 };

--- a/src/CGALWrapper-inl.h
+++ b/src/CGALWrapper-inl.h
@@ -63,14 +63,16 @@ v8::Handle<v8::Value> CGALWrapper<WrapperClass, CGALClass>::New(const CGALClass 
 
 template<typename WrapperClass, typename CGALClass>
 template<typename ForwardIterator>
-v8::Handle<v8::Value> CGALWrapper<WrapperClass, CGALClass>::SeqToPOD(ForwardIterator first, ForwardIterator last)
+v8::Handle<v8::Value> CGALWrapper<WrapperClass, CGALClass>::SeqToPOD(
+    ForwardIterator first, ForwardIterator last,
+    bool precise)
 {
     v8::HandleScope scope;
     v8::Local<v8::Array> array = v8::Array::New();
     ForwardIterator it;
     uint32_t i;
     for(it=first,i=0; it!=last; ++it,++i) {
-        array->Set(i, WrapperClass::ToPOD(*it));
+        array->Set(i, WrapperClass::ToPOD(*it, precise));
     }
     return scope.Close(array);
 }
@@ -126,7 +128,15 @@ v8::Handle<v8::Value> CGALWrapper<WrapperClass, CGALClass>::ToPOD(const v8::Argu
 {
     v8::HandleScope scope;
     WrapperClass *wrapper = ObjectWrap::Unwrap<WrapperClass>(args.This());
-    return scope.Close(WrapperClass::ToPOD(wrapper->mWrapped));
+    ARGS_ASSERT(args.Length() <= 1)
+
+    bool precise = true;
+    if (args.Length() == 1) {
+        ARGS_ASSERT(args[0]->IsBoolean())
+        precise = args[0]->BooleanValue();
+    }
+
+    return scope.Close(WrapperClass::ToPOD(wrapper->mWrapped, precise));
 }
 
 

--- a/src/CGALWrapper.h
+++ b/src/CGALWrapper.h
@@ -22,7 +22,7 @@ public:
     static bool ParseSeqArg(v8::Local<v8::Value> arg, OutputIterator iterator);
 
     template<typename ForwardIterator>
-    static v8::Handle<v8::Value> SeqToPOD(ForwardIterator first, ForwardIterator last);
+    static v8::Handle<v8::Value> SeqToPOD(ForwardIterator first, ForwardIterator last, bool precise);
 
 protected:
 

--- a/src/Curve2.cc
+++ b/src/Curve2.cc
@@ -61,7 +61,7 @@ bool Curve2::ParseArg(Local<Value> arg, Curve_2 &receiver)
 }
 
 
-Handle<Value> Curve2::ToPOD(const Curve_2 &curve)
+Handle<Value> Curve2::ToPOD(const Curve_2 &curve, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();

--- a/src/Curve2.h
+++ b/src/Curve2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Arr_linear_traits_2::Curve_2 class
-
 class Curve2 : public CGALWrapper<Curve2, Curve_2>
 {
 public:
@@ -20,20 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 argument into the CGAL Curve_2 object referred to by receiver.  Accepts 
-    // either a Curve2 JS object or ... 
-    // Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Curve_2 &receiver);
 
-    // Convert a CGAL Curve_2 object to a POD v8 object.  This renders a Curve_2 to ...
-    // and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Curve_2 &curve);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Curve_2 &curve, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL Curve_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
     static v8::Handle<v8::Value> IsSegment(const v8::Arguments &args);

--- a/src/D2.cc
+++ b/src/D2.cc
@@ -3,6 +3,7 @@
 #include "cgal_types.h"
 #include "node.h"
 #include "v8.h"
+#include "AffTransformation2.h"
 #include "Point2.h"
 #include "Polygon2.h"
 #include "PolygonWithHoles2.h"
@@ -17,6 +18,7 @@ void D2::Init(v8::Handle<v8::Object> exports)
     exports->Set(String::NewSymbol("doIntersect"), FunctionTemplate::New(DoIntersect)->GetFunction());
     exports->Set(String::NewSymbol("convexPartition2"), FunctionTemplate::New(ConvexPartition2)->GetFunction());
     exports->Set(String::NewSymbol("convexHull2"), FunctionTemplate::New(ConvexHull2)->GetFunction());
+    exports->Set(String::NewSymbol("collinear"), FunctionTemplate::New(Collinear)->GetFunction());
 }
 
 Handle<Value> DoIntersect(const Arguments &args)
@@ -120,6 +122,28 @@ Handle<Value> ConvexHull2(const Arguments& args)
         }
 
         return scope.Close(array);
+    }
+
+    catch(const exception &e) {
+        return ThrowException(String::New(e.what()));
+    }
+
+}
+
+
+Handle<Value> Collinear(const Arguments &args)
+{
+    HandleScope scope;
+
+    try {
+
+        ARGS_ASSERT(args.Length() == 3);
+        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, p0, args[0])
+        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, p1, args[1])
+        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, p2, args[2])
+
+        return scope.Close(Boolean::New(CGAL::collinear(p0, p1, p2)));
+
     }
 
     catch(const exception &e) {

--- a/src/D2.h
+++ b/src/D2.h
@@ -25,4 +25,6 @@ v8::Handle<v8::Value> ConvexHull2(const v8::Arguments &args);
 // intersect.
 v8::Handle<v8::Value> DoIntersect(const v8::Arguments &args);
 
+v8::Handle<v8::Value> Collinear(const v8::Arguments &args);
+
 #endif // !defined(D2_H)

--- a/src/Direction2.cc
+++ b/src/Direction2.cc
@@ -77,13 +77,13 @@ bool Direction2::ParseArg(Local<Value> arg, Direction_2 &receiver)
             return true;
         }
 
-    } 
+    }
 
     return false;
 }
 
 
-Handle<Value> Direction2::ToPOD(const Direction_2 &direction)
+Handle<Value> Direction2::ToPOD(const Direction_2 &direction, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();

--- a/src/Direction2.h
+++ b/src/Direction2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Direction_2 class
-
 class Direction2 : public CGALWrapper<Direction2, Direction_2>
 {
 public:
@@ -20,20 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 object into the CGAL Direction_2 object referred to by receiver.
-    // Accepts either a Direction2 object or ... Returns true if parse was successful, false 
-    // otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Direction_2 &receiver);
 
-    // Convert a CGAL::Direction_2 object to a POD v8 object.  This renders a direction to an 
-    // object ... and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Direction_2 &direction);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Direction_2 &direction, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Direction_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
     static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);

--- a/src/Line2.cc
+++ b/src/Line2.cc
@@ -79,7 +79,7 @@ bool Line2::ParseArg(Local<Value> arg, Line_2 &receiver)
 }
 
 
-Handle<Value> Line2::ToPOD(const Line_2 &line)
+Handle<Value> Line2::ToPOD(const Line_2 &line, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();

--- a/src/Line2.h
+++ b/src/Line2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Line_2 class
-
 class Line2 : public CGALWrapper<Line2, Line_2>
 {
 public:
@@ -20,40 +18,25 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 value into the CGAL Line_2 object referred to by receiver.  Accepts
-    // either a Line2 object, an object of form {a:,b:,c:} where the values of a, b, and c are
-    // doubles representing coefficients of the line equation ax + by + c = 0, or an object of the
-    // form {p:,q:} where the values of p and q are Point2 constructables representing two points
-    // on the line.  Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Line_2 &receiver);
 
-    // Convert a CGAL::Line_2 object to a POD v8 object of the form {a:,b:,c:} where the values of
-    // a, b, and c are doubles representing coefficients of the line equation ax + by + c = 0.  This
-    // may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Line_2 &Line);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Line_2 &Line, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Line_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
-    // Returns true if this line and line provided by argument are overlapping and
-    // oriented in the same direction.
     static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);
-
-    // Returns true if the a and b coefficients of the line are both zero.
     static v8::Handle<v8::Value> IsDegenerate(const v8::Arguments &args);
-
-    // Returns true if the endpoints of this edge have the same y coordinate.
     static v8::Handle<v8::Value> IsHorizontal(const v8::Arguments &args);
-
-    // Returns true if the endpoints of this edge have the same x coordinate.
     static v8::Handle<v8::Value> IsVertical(const v8::Arguments &args);
-
-    // Returns an abitrary point on the line, given an integer index.  It holds that point(i) is
-    // Returns the incident line oriented in the opposite direction.
     static v8::Handle<v8::Value> Opposite(const v8::Arguments &args);
 
 };

--- a/src/NefPolyhedron2.cc
+++ b/src/NefPolyhedron2.cc
@@ -45,7 +45,7 @@ bool NefPolyhedron2::ParseArg(Local<Value> arg, Nef_polyhedron_2 &receiver)
 }
 
 
-Handle<Value> NefPolyhedron2::ToPOD(const Nef_polyhedron_2 &nef)
+Handle<Value> NefPolyhedron2::ToPOD(const Nef_polyhedron_2 &nef, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();

--- a/src/NefPolyhedron2.h
+++ b/src/NefPolyhedron2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Nef_polyhedron_2 class
-
 class NefPolyhedron2 : public CGALWrapper<NefPolyhedron2, Nef_polyhedron_2>
 {
 public:
@@ -20,20 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 argument into the CGAL Nef_polyhedron_2 object referred to by receiver.
-    // Accepts either a NefPolyhedron2 JS object or ...  Returns true if parse was successful,
-    // false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Nef_polyhedron_2 &receiver);
 
-    // Convert a CGAL::Nef_polyhedron_2 object to a POD v8 object of the form... This may lose
-    // precision.
-    static v8::Handle<v8::Value> ToPOD(const Nef_polyhedron_2 &nef);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Nef_polyhedron_2 &nef, bool precise=false);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Nef_polyhedron_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
 };

--- a/src/Point2.cc
+++ b/src/Point2.cc
@@ -1,5 +1,7 @@
 #include "Point2.h"
+#include "AffTransformation2.h"
 #include "cgal_args.h"
+#include "iomanip"
 
 using namespace v8;
 using namespace node;
@@ -11,8 +13,11 @@ const char *Point2::Name = "Point2";
 
 void Point2::RegisterMethods()
 {
+    SetPrototypeMethod(sConstructorTemplate, "toString", ToString);
+    SetPrototypeMethod(sConstructorTemplate, "isEqual", IsEqual);
     SetPrototypeMethod(sConstructorTemplate, "x", X);
     SetPrototypeMethod(sConstructorTemplate, "y", Y);
+    SetPrototypeMethod(sConstructorTemplate, "transform", Transform);
 }
 
 
@@ -27,35 +32,103 @@ bool Point2::ParseArg(Local<Value> arg, Point_2 &receiver)
 
     } else if (arg->IsArray()) {
 
-        // This supports e.g.: newPoint = new CGAL.Point2([0,0]);
-
         Local<Array> coords = Local<Array>::Cast(arg);
 
-        if ((coords->Length() < 2)
-            || !coords->Get(0)->IsNumber()
-            || !coords->Get(1)->IsNumber())
-        {
+        if (coords->Length() < 2)
+            return false;
+
+        if (coords->Get(0)->IsNumber() && coords->Get(1)->IsNumber()) {
+
+            receiver = Point_2(coords->Get(0)->NumberValue(), coords->Get(1)->NumberValue());
+            return true;
+
+        } else if (coords->Get(0)->IsString() && coords->Get(1)->IsString()) {
+
+#ifdef CGAL_USE_EPECK
+
+            K::FT x(CGAL::Epeck_ft(*String::AsciiValue(coords->Get(0))));
+            K::FT y(CGAL::Epeck_ft(*String::AsciiValue(coords->Get(1))));
+
+#else // !defined(CGAL_USE_EPECK)
+
+            istringstream xstr(*String::AsciiValue(coords->Get(0)));
+            K::FT x;
+            xstr >> x;
+
+            istringstream ystr(*String::AsciiValue(coords->Get(1)));
+            K::FT y;
+            ystr >> y;
+
+#endif // !defined(CGAL_USE_EPECK)
+
+            receiver = Point_2(x, y);
+            return true;
+
+        } else {
             return false;
         }
 
-        receiver = Point_2(coords->Get(0)->NumberValue(), coords->Get(1)->NumberValue());
-        return true;
-
     } else {
-
         return false;
-
     }
+
 }
 
 
-Handle<Value> Point2::ToPOD(const Point_2 &point)
+Handle<Value> Point2::ToPOD(const Point_2 &point, bool precise)
 {
     HandleScope scope;
     Local<Array> array = Array::New(2);
-    array->Set(0, Number::New(CGAL::to_double(point.cartesian(0))));
-    array->Set(1, Number::New(CGAL::to_double(point.cartesian(1))));
+
+    if (precise) {
+
+        ostringstream x_str;
+#if CGAL_USE_EPECK
+        x_str << point.x().exact();
+#else
+        x_str << setprecision(20) << point.x();
+#endif
+        array->Set(0, String::New(x_str.str().c_str()));
+
+        ostringstream y_str;
+#if CGAL_USE_EPECK
+        y_str << point.y().exact();
+#else
+        y_str << setprecision(20) << point.y();
+#endif
+        array->Set(1, String::New(y_str.str().c_str()));
+
+    } else {
+        array->Set(0, Number::New(CGAL::to_double(point.cartesian(0))));
+        array->Set(1, Number::New(CGAL::to_double(point.cartesian(1))));
+    }
+
     return scope.Close(array);
+}
+
+
+Handle<Value> Point2::ToString(const v8::Arguments &args)
+{
+    HandleScope scope;
+    Point_2 &point = ExtractWrapped(args.This());
+    ostringstream str;
+    str << "[object "  << Name << " " << point << "]";
+    return scope.Close(String::New(str.str().c_str()));
+}
+
+
+Handle<Value> Point2::IsEqual(const Arguments &args)
+{
+    HandleScope scope;
+    try {
+        Point_2 &thisPoint = ExtractWrapped(args.This());
+        ARGS_ASSERT(args.Length() == 1);
+        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, otherPoint, args[0]);
+        return scope.Close(Boolean::New(thisPoint == otherPoint));
+    }
+    catch (const exception &e) {
+        return ThrowException(String::New(e.what()));
+    }
 }
 
 
@@ -82,4 +155,26 @@ Handle<Value> Point2::Y(const Arguments &args)
     catch (const exception &e) {
         return ThrowException(String::New(e.what()));
     }
+}
+
+
+Handle<Value> Point2::Transform(const Arguments &args)
+{
+  HandleScope scope;
+  try {
+    Point_2 &point = ExtractWrapped(args.This());
+    ARGS_ASSERT(args.Length() == 1);
+
+
+    Aff_transformation_2 afft;
+    if (AffTransformation2::ParseArg(args[0], afft)) {
+      Point_2 new_point = point.transform(afft);
+      return scope.Close(New(new_point));
+    }
+
+    ARGS_ASSERT(false);
+  }
+  catch (const exception &e) {
+    return ThrowException(String::New(e.what()));
+  }
 }

--- a/src/Polygon2.h
+++ b/src/Polygon2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Polygon_2 class.
-
 class Polygon2 : public CGALWrapper<Polygon2, Polygon_2>
 {
 public:
@@ -20,15 +18,13 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 argument into the CGAL Polygon_2 object referred to
-    // by receiver.  Accepts either a Polygon2 JS object or an array of objects
-    // that are constructable to Point2 objects. Returns true if parse was successful,
-    // false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Polygon_2 &receiver);
 
-    // Convert a CGAL::Polygon_2 object to a POD v8 object.  This renders a polygon to
-    // an array of arrays of two doubles, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Polygon_2 &poly);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Polygon_2 &poly, bool precise=true);
 
 private:
 
@@ -37,31 +33,16 @@ private:
     //      the semantics and names of CGAL::Point_2 methods.
     //
 
-    // Test for equality: two polygons are equal iff there exists a cyclic permutation of the
-    // vertices of p2 such that they are equal to the vertices of p1.
+    static v8::Handle<v8::Value> ToString(const v8::Arguments &args);
     static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);
-
-    // Returns true of this polygon is simple (edges don't intersect except at vertices).
     static v8::Handle<v8::Value> IsSimple(const v8::Arguments &args);
-
-    // Returns true of this polygon is convex.
     static v8::Handle<v8::Value> IsConvex(const v8::Arguments &args);
-
-    // Returns constant CGAL.COUNTERCLOCKWISE, CGAL.CLOCKWISE, or CGAL::COLLINEAR).
     static v8::Handle<v8::Value> Orientation(const v8::Arguments &args);
-
-    // Takes a point as an argument (Point2 or POD rep) and returns constant CGAL.POSITIVE_SIDE,
-    // CGAL.NEGATIVE_SIDE, or CGAL.ON_ORIENTED_BOUNDARY, depending on where the point is in relation
-    // to this polygon.
     static v8::Handle<v8::Value> OrientedSide(const v8::Arguments &args);
-
-    // Takes a point as an argument (Point2 or POD rep) and returns constant CGAL.ON_BOUNDED_SIDE,
-    // CGAL.ON_BOUNDARY or CGAL.ON_UNBOUNDED_SIDE, depending on where the point is in relation to
-    // this polygon.
     static v8::Handle<v8::Value> BoundedSide(const v8::Arguments &args);
-
-    // Returns the signed area of this polygon (negative if orientation is clockwise).
     static v8::Handle<v8::Value> Area(const v8::Arguments &args);
+    static v8::Handle<v8::Value> Transform(const v8::Arguments &args);
+    static v8::Handle<v8::Value> Coords(const v8::Arguments &args);
 
 };
 

--- a/src/PolygonSet2.cc
+++ b/src/PolygonSet2.cc
@@ -61,12 +61,12 @@ bool PolygonSet2::ParseArg(Local<Value> arg, Polygon_set_2 &receiver)
 }
 
 
-Handle<Value> PolygonSet2::ToPOD(const Polygon_set_2 &polySet)
+Handle<Value> PolygonSet2::ToPOD(const Polygon_set_2 &polySet, bool precise)
 {
     HandleScope scope;
     vector<Polygon_with_holes_2> pwhs;
     polySet.polygons_with_holes(back_inserter(pwhs));
-    return scope.Close(PolygonWithHoles2::SeqToPOD(pwhs.begin(), pwhs.end()));
+    return scope.Close(PolygonWithHoles2::SeqToPOD(pwhs.begin(), pwhs.end(), precise));
 }
 
 

--- a/src/PolygonSet2.h
+++ b/src/PolygonSet2.h
@@ -18,24 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 value into the CGAL Polygon_with_holes_2 object referred to by
-    // receiver.  Accepts either a PolygonWithHoles2 object, a Polygon2 constructable taken as the
-    // boundary (no holes), or an object of form {boundary:,holes:}, where the value of boundary
-    // is a Polygon2 constructable and the value of holes is an array of Polygon2 constructables.
-    // Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Polygon_set_2 &receiver);
 
-    // Convert a CGAL::Polygon_with_holes_2 object to a POD v8 object.  This renders a poly with
-    // holes as an object of form {boundary:,holes:}, where the value of boundary is the POD rep
-    // of the boundary poly, and the value of holes is an array of POD reps of hole polys.  This
-    // may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Polygon_set_2 &polySet);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Polygon_set_2 &polySet, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Polygon_with_holes_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
     static v8::Handle<v8::Value> PolygonsWithHoles(const v8::Arguments &args);

--- a/src/PolygonWithHoles2.cc
+++ b/src/PolygonWithHoles2.cc
@@ -23,16 +23,12 @@ bool PolygonWithHoles2::ParseArg(Local<Value> arg, Polygon_with_holes_2 &receive
 {
     if (sConstructorTemplate->HasInstance(arg)) {
 
-        // This supports e.g.: newpwh = new CGAL.PolygonWithHoles2(oldpwh);
-
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
 
     } else if (arg->IsObject()) {
 
         Local<Object> inits = Local<Object>::Cast(arg);
-
-        // This supports e.g.: pwh = new CGAL.PolygonWithHoles2({outer:,holes:})
 
         if (inits->Has(String::NewSymbol("outer")) &&
             inits->Has(String::NewSymbol("holes")) )
@@ -52,8 +48,6 @@ bool PolygonWithHoles2::ParseArg(Local<Value> arg, Polygon_with_holes_2 &receive
             receiver = Polygon_with_holes_2(outer, holes.begin(), holes.end());
             return true;
         }
-
-        // This supports e.g. pwh = new CGAL.PolygonWithHoles2(aPolygon2)
 
         else {
 
@@ -75,12 +69,12 @@ bool PolygonWithHoles2::ParseArg(Local<Value> arg, Polygon_with_holes_2 &receive
 }
 
 
-Handle<Value> PolygonWithHoles2::ToPOD(const Polygon_with_holes_2 &poly)
+Handle<Value> PolygonWithHoles2::ToPOD(const Polygon_with_holes_2 &poly, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();
-    obj->Set(String::NewSymbol("outer"), Polygon2::ToPOD(poly.outer_boundary()));
-    obj->Set(String::NewSymbol("holes"), Polygon2::SeqToPOD(poly.holes_begin(), poly.holes_end()));
+    obj->Set(String::NewSymbol("outer"), Polygon2::ToPOD(poly.outer_boundary(), precise));
+    obj->Set(String::NewSymbol("holes"), Polygon2::SeqToPOD(poly.holes_begin(), poly.holes_end(), precise));
     return scope.Close(obj);
 }
 

--- a/src/PolygonWithHoles2.h
+++ b/src/PolygonWithHoles2.h
@@ -18,24 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 value into the CGAL Polygon_with_holes_2 object referred to by
-    // receiver.  Accepts either a PolygonWithHoles2 object, a Polygon2 constructable taken as the
-    // boundary (no holes), or an object of form {outer:,holes:}, where the value of boundary
-    // is a Polygon2 constructable and the value of holes is an array of Polygon2 constructables.
-    // Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Polygon_with_holes_2 &receiver);
 
-    // Convert a CGAL::Polygon_with_holes_2 object to a POD v8 object.  This renders a poly with
-    // holes as an object of form {outer:,holes:}, where the value of boundary is the POD rep
-    // of the boundary poly, and the value of holes is an array of POD reps of hole polys.  This
-    // may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Polygon_with_holes_2 &poly);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Polygon_with_holes_2 &poly, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Polygon_with_holes_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
     static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);

--- a/src/Ray2.cc
+++ b/src/Ray2.cc
@@ -117,12 +117,12 @@ bool Ray2::ParseArg(Local<Value> arg, Ray_2 &receiver)
 }
 
 
-Handle<Value> Ray2::ToPOD(const Ray_2 &ray)
+Handle<Value> Ray2::ToPOD(const Ray_2 &ray, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();
-    obj->Set(String::NewSymbol("p"), Point2::ToPOD(ray.source()));
-    obj->Set(String::NewSymbol("d"), Direction2::ToPOD(ray.direction()));
+    obj->Set(String::NewSymbol("p"), Point2::ToPOD(ray.source(), precise));
+    obj->Set(String::NewSymbol("d"), Direction2::ToPOD(ray.direction(), precise));
     return scope.Close(obj);
 }
 

--- a/src/Ray2.h
+++ b/src/Ray2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Ray_2 class
-
 class Ray2 : public CGALWrapper<Ray2, Ray_2>
 {
 public:
@@ -20,19 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 object into the CGAL Ray_2 object referred to by receiver. Accepts
-    // either a Ray2 object or ... Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Ray_2 &receiver);
 
-    // Convert a CGAL::Ray_2 object to a POD v8 object.  This renders a ray to an object
-    // ... and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Ray_2 &ray);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Ray_2 &ray, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Ray_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
     static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);

--- a/src/Segment2.cc
+++ b/src/Segment2.cc
@@ -57,12 +57,12 @@ bool Segment2::ParseArg(Local<Value> arg, Segment_2 &receiver)
 }
 
 
-Handle<Value> Segment2::ToPOD(const Segment_2 &segment)
+Handle<Value> Segment2::ToPOD(const Segment_2 &segment, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();
-    obj->Set(String::NewSymbol("source"), Point2::ToPOD(segment.source()));
-    obj->Set(String::NewSymbol("target"), Point2::ToPOD(segment.target()));
+    obj->Set(String::NewSymbol("source"), Point2::ToPOD(segment.source(), precise));
+    obj->Set(String::NewSymbol("target"), Point2::ToPOD(segment.target(), precise));
     return scope.Close(obj);
 }
 

--- a/src/Segment2.h
+++ b/src/Segment2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Segment_2 class
-
 class Segment2 : public CGALWrapper<Segment2, Segment_2>
 {
 public:
@@ -20,26 +18,22 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 object into the CGAL Segment_2 object referred to by receiver. Accepts
-    // either a Segment2 object or an object of form {source:,target:}, where the values of source
-    // and target are Point2 constructables.  Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Segment_2 &receiver);
 
-    // Convert a CGAL::Segment_2 object to a POD v8 object.  This renders a segment to and object
-    // {source: [double,double], target: [double, double]}, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Segment_2 &segment);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Segment_2 &segment, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Segment_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
-    // Returns true if the endpoints of this edge have the same y coordinate.
     static v8::Handle<v8::Value> IsHorizontal(const v8::Arguments &args);
-
-    // Returns true if the endpoints of this edge have the same x coordinate.
     static v8::Handle<v8::Value> IsVertical(const v8::Arguments &args);
 
 };

--- a/src/Vector2.cc
+++ b/src/Vector2.cc
@@ -61,13 +61,13 @@ bool Vector2::ParseArg(Local<Value> arg, Vector_2 &receiver)
             return true;
         }
 
-    } 
+    }
 
     return false;
 }
 
 
-Handle<Value> Vector2::ToPOD(const Vector_2 &vector)
+Handle<Value> Vector2::ToPOD(const Vector_2 &vector, bool precise)
 {
     HandleScope scope;
     Local<Object> obj = Object::New();

--- a/src/Vector2.h
+++ b/src/Vector2.h
@@ -6,8 +6,6 @@
 #include "v8.h"
 
 
-// Wraps the CGAL::Vector_2 class
-
 class Vector2 : public CGALWrapper<Vector2, Vector_2>
 {
 public:
@@ -20,19 +18,19 @@ public:
     // init function.
     static void RegisterMethods();
 
-    // Attempt to parse a v8 object into the CGAL Vector_2 object referred to by receiver. Accepts
-    // either a Vector2 object or ... Returns true if parse was successful, false otherwise.
+    // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
+    // if parse was successful, false otherwise.
     static bool ParseArg(v8::Local<v8::Value> arg, Vector_2 &receiver);
 
-    // Convert a CGAL::Vector_2 object to a POD v8 object.  This renders a vector to an object
-    // ... and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Vector_2 &vector);
+    // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
+    // will attempt to render in terms of doubles for coordinates, and may lose precision.
+    static v8::Handle<v8::Value> ToPOD(const Vector_2 &vector, bool precise=true);
 
 private:
 
     //
     //----- The following methods will be callable from JS.  These will mostly match
-    //      the semantics and names of CGAL::Vector_2 methods.
+    //      the semantics and names of the wrapped CGAL class.
     //
 
 };

--- a/src/cgal.cc
+++ b/src/cgal.cc
@@ -3,6 +3,7 @@
 #include "cgal_types.h"
 #include "node.h"
 #include "v8.h"
+#include "AffTransformation2.h"
 #include "Arrangement2.h"
 #include "BBox2.h"
 #include "Curve2.h"
@@ -89,6 +90,7 @@ void init(Handle<Object> exports)
     NODE_DEFINE_CONSTANT(exports, ARR_TOP_BOUNDARY);
     NODE_DEFINE_CONSTANT(exports, ARR_INTERIOR);
 
+    AffTransformation2::Init(exports);
     Arrangement2::Init(exports);
     BBox2::Init(exports);
     Curve2::Init(exports);

--- a/src/cgal_types.h
+++ b/src/cgal_types.h
@@ -3,12 +3,12 @@
 
 //
 // If CGAL_USE_APPROX is defined, we parameterize the kernel stack in the wrappers to be based
-// on the Vannevar approximate interval number type; otherwise we configure with the stock GCAL 
+// on the Vannevar approximate interval number type; otherwise we configure with the stock GCAL
 // epick (exact predicates, inexact constructions) kernel.
-// 
+//
 // The Vannevar approximate interval stack is still early in development and not included in this
 // release, but we hope to include it soon in an updated release.
-// 
+//
 
 #if defined(CGAL_USE_APPROX)
 #include "CGAL/Interval_nt_approx.h"
@@ -54,6 +54,8 @@ typedef CGAL::Segment_2<K> Segment_2;
 typedef CGAL::Line_2<K> Line_2;
 typedef CGAL::Ray_2<K> Ray_2;
 typedef CGAL::Vector_2<K> Vector_2;
+typedef CGAL::Aff_transformation_2<K> Aff_transformation_2;
+typedef CGAL::Rotation Rotation;
 typedef K::Point_2 Point_2;
 typedef Polygon_2::Vertex_iterator Vertex_iterator;
 typedef CGAL::Extended_cartesian<K::FT> EK;

--- a/test/Arrangement2.spec.js
+++ b/test/Arrangement2.spec.js
@@ -26,7 +26,7 @@ describe("CGAL.Arrangement2", function() {
 
     it("should report the number of face, bounded faces, unbounded faces, and vertices in the arrangement", function(){
         arr.insertLines([l1,l2,l3]);
-        var arrPOD = arr.toPOD();
+        var arrPOD = arr.toPOD(false);
         expect(arrPOD.numFaces).toEqual(7);
         expect(arrPOD.numUnboundedFaces).toEqual(6);
         expect(arrPOD.numBoundedFaces).toEqual(1);
@@ -35,13 +35,13 @@ describe("CGAL.Arrangement2", function() {
 
     it("should report the bounded faces within the arrangement", function(){
         arr.insertLines([l1,l2,l3]);
-        var faces = arr.toPOD().boundedFaces;
+        var faces = arr.toPOD(false).boundedFaces;
         expect(faces.length).toEqual(1);
         expect(faces[0]).toEqual([[1,1], [9,1], [5,5]]);
 
         var l4 = new CGAL.Line2({p: [-1,9], q:[11,9]});
         arr.insertLines([l4]);
-        faces = arr.toPOD().boundedFaces;
+        faces = arr.toPOD(false).boundedFaces;
         expect(faces.length).toEqual(2);
         expect(faces[0]).toEqual([[9,9], [1,9], [5,5]]);
     });

--- a/test/D2.spec.js
+++ b/test/D2.spec.js
@@ -5,13 +5,13 @@ describe("CGAL.convexPartition2", function() {
 
     it("should convexify a concave poly", function() {
         var result = CGAL.convexPartition2([[0,0],[5,5],[10,0],[10,10],[0,10]]);
-        result = result.map(function(subresult) { return subresult.toPOD(); });
+        result = result.map(function(subresult) { return subresult.toPOD(false); });
         expect(result).toEqual([[[5,5],[10,0],[10,10],[0,10]],[[0,0],[5,5],[0,10]]]);
     });
 
     it("should pass convex poly unchanged", function() {
         var result = CGAL.convexPartition2([[0,0],[10,0],[0,10]]);
-        result = result.map(function(subresult) { return subresult.toPOD(); });
+        result = result.map(function(subresult) { return subresult.toPOD(false); });
         expect(result).toEqual([[[0,0],[10,0],[0,10]]]);
     });
 
@@ -39,13 +39,13 @@ describe("CGAL.convexHull2", function() {
 
     it("should convexify a set of points", function() {
         var result = CGAL.convexHull2([[0,0],[5,5],[10,0],[10,10],[0,10]]);
-        result = result.map(function(subresult) { return subresult.toPOD(); });
+        result = result.map(function(subresult) { return subresult.toPOD(false); });
         expect(result).toEqual([[0,0],[10,0],[10,10],[0,10]]);
     });
 
     it("should pass a convex set of points unchanged", function() {
         var result = CGAL.convexHull2([[0,0],[10,0],[10,10],[0,10]]);
-        result = result.map(function(subresult) { return subresult.toPOD(); });
+        result = result.map(function(subresult) { return subresult.toPOD(false); });
         expect(result).toEqual([[0,0],[10,0],[10,10],[0,10]]);
     });
 

--- a/test/Point2.spec.js
+++ b/test/Point2.spec.js
@@ -8,6 +8,8 @@ describe("CGAL.Point2", function() {
         expect(function() { return new CGAL.Point2(); }).not.toThrow();
         expect(function() { return new CGAL.Point2([]); }).toThrow();
         expect(function() { return new CGAL.Point2(1,2); }).toThrow();
+        expect(function() { return new CGAL.Point2(["1", "3"]); }).not.toThrow();
+        expect(function() { return new CGAL.Point2(["1/3", "3.1435"]); }).not.toThrow();
     });
 
     it("should be constructable from another instance", function() {
@@ -17,10 +19,24 @@ describe("CGAL.Point2", function() {
 
     it("should be renderable via toPOD", function() {
         var p = new CGAL.Point2([1,0]);
-        var point = p.toPOD();
+        var point = p.toPOD(false);
         expect(point.length).toBe(2);
         expect(point[0]).toBe(1);
         expect(point[1]).toBe(0);
     });
 
+    it("should be serializable and revivable from serialized form", function() {
+        var p = new CGAL.Point2([0.1+0.2, 103/432667]);
+        var q = new CGAL.Point2(p.toPOD());
+        expect(p.toPOD()).toEqual(q.toPOD());
+        expect(p.x()).toEqual(q.x());
+     });
+
+    it("should be transformable", function() {
+        var p = new CGAL.Point2([1,2]);
+        var q = p.transform([1, 0, 3, 0, 1, 3]);
+        expect(q instanceof CGAL.Point2).toBeTruthy();
+        expect(q.x()).toEqual(4);
+        expect(q.y()).toEqual(5);
+    });
 });

--- a/test/Polygon2.spec.js
+++ b/test/Polygon2.spec.js
@@ -6,8 +6,10 @@ describe("CGAL.Polygon2", function() {
     it("should be constructable from an array of points", function() {
         expect(function() { return new CGAL.Polygon2([[0,0], [1,1], [0,2]]); }).not.toThrow();
         expect(function() { return new CGAL.Polygon2(); }).not.toThrow();
-        expect(function() { return new CGAL.Polygon2([]); }).toThrow();
+        expect(function() { return new CGAL.Polygon2([]); }).not.toThrow();
         expect(function() { return new CGAL.Polygon2([[0,0]]); }).not.toThrow();
+        expect(function() { return new CGAL.Polygon2([["1", "4"], ["3/1", "0.0"], ["343/1234", "0"]]); }).not.toThrow();
+        expect(function() { return new CGAL.Polygon2([["1", "4"], ["3/1", "0.0"], [0, 2]]); }).not.toThrow();
     });
 
     it("should be constructable from another instance", function() {
@@ -18,7 +20,7 @@ describe("CGAL.Polygon2", function() {
     it("should be renderable via toPOD", function() {
         var points = [[0,0], [1,1], [0,2]];
         var p = new CGAL.Polygon2(points);
-        var poly = p.toPOD();
+        var poly = p.toPOD(false);
         expect(poly.length).toBe(3);
         expect(poly).toEqual(points);
     });
@@ -29,6 +31,13 @@ describe("CGAL.Polygon2", function() {
         var p3 = new CGAL.Polygon2([[0,0],[0,1],[1,1],[1,0]]);
         expect(p1.isEqual(p2)).toBeTruthy();
         expect(p1.isEqual(p3)).toBeFalsy();
+    });
+
+    it("should be serializable and revivable from serialized form", function() {
+        var p1 = new CGAL.Polygon2([[0,0],[0.2+0.1,0],[1,1],[0,1]]);
+        var p2 = new CGAL.Polygon2(p1.toPOD());
+        expect(p1.toPOD()).toEqual(p2.toPOD());
+        expect(p1.isEqual(p2)).toBeTruthy();
     });
 
     it("isSimple predicate should function as expected", function() {
@@ -85,4 +94,10 @@ describe("CGAL.Polygon2", function() {
         expect(p3.area()).toBeCloseTo(-1.0, 4);
     });
 
+    it ("should support transformation", function() {
+        var p1 = new CGAL.Polygon2([[0, 0], [1, 0], [1, 1], [0, 1]]);
+        var p2;
+        expect(function() {p2 = CGAL.Polygon2.transform([1, 0, 3, 0, 1, 3], p1);}).not.toThrow();
+        expect(p2.toPOD(false)[0]).toEqual([3,3]);
+    });
 });

--- a/test/PolygonSet2.spec.js
+++ b/test/PolygonSet2.spec.js
@@ -17,7 +17,7 @@ describe("CGAL.PolygontSet2", function() {
         var pset2 = new CGAL.PolygonSet2();
         var p2 = new CGAL.Polygon2([[0,0],[1,0],[1,1],[0,1]]);
         pset2.insert(p2);
-        expect(JSON.stringify(pset2.toPOD()))
+        expect(JSON.stringify(pset2.toPOD(false)))
             .toEqual('[{"outer":[[0,0],[1,0],[1,1],[0,1]],"holes":[]}]');
     });
 

--- a/test/PolygonWithHoles2.spec.js
+++ b/test/PolygonWithHoles2.spec.js
@@ -10,6 +10,16 @@ describe("CGAL.PolygonWithHoles2", function() {
         expect(function() { return new CGAL.PolygonWithHoles2({}); }).toThrow();
         expect(function() { return new CGAL.PolygonWithHoles2({outer:[[0,0], [1,1], [0,2]]}); }).toThrow();
         expect(function() { return new CGAL.PolygonWithHoles2([[0,0], [1,1], [0,2]]); }).not.toThrow();
+        expect(function() { return new CGAL.PolygonWithHoles2({outer:[[0,0], ["1","1"], [0,0.2+0.1]], holes: [[[1,1], [2,2], ["-1.2345","5"]]]}); }).not.toThrow();
+        function point(p) {
+            return new CGAL.Point2(p);
+        }
+        expect(function() { return new CGAL.PolygonWithHoles2(
+            {
+                outer:[new CGAL.Point2([0,0]), new CGAL.Point2([1,1]), new CGAL.Point2([0,2])],
+                holes: []
+            }
+        ); }).not.toThrow();
     });
 
     it("should be constructable from another instance", function() {
@@ -21,10 +31,19 @@ describe("CGAL.PolygonWithHoles2", function() {
         var outer = [[0,0], [1,1], [0,2]],
             hole = [[1,1], [2,2], [-1,5]];
         var p = new CGAL.PolygonWithHoles2({outer:outer, holes: [hole]});
-        var poly = p.toPOD();
+        var poly = p.toPOD(false);
         expect(poly.outer).toEqual(outer);
         expect(poly.holes.length).toBe(1);
         expect(poly.holes[0]).toEqual(hole);
+    });
+
+    it("should be serializable and revivable", function() {
+        var outer = [[0,0], [1,1], [0,2]],
+            hole = [[0.1+0.2,1], [2,2], [-1,5]];
+        var p = new CGAL.PolygonWithHoles2({outer:outer, holes: [hole]});
+        var q = new CGAL.PolygonWithHoles2(p.toPOD());
+        expect(p.toPOD()).toEqual(q.toPOD());
+        expect(p.isEqual(q)).toBeTruthy();
     });
 
 });

--- a/test/Segment2.spec.js
+++ b/test/Segment2.spec.js
@@ -11,7 +11,7 @@ describe("CGAL.Segment2", function() {
 
     it("should be renderable via toPOD", function() {
         var hl = new CGAL.Segment2({source:[0,0], target:[1,0]});
-        var pod = hl.toPOD();
+        var pod = hl.toPOD(false);
         expect(pod.source).toEqual([0,0]);
         expect(pod.target).toEqual([1,0]);
     });


### PR DESCRIPTION
- This cl is mostly concerned with extending ToPOD and ParseArg
  methods to support precise serialization/deserialization.  ToPOD
  now takes an optional "precise" argument (default true) -- when
  this is set to true, FT and RT leaves of serialization tree are
  serialized to precise string representations dependent on the
  kernel in use.  When the precise argument is false, FT and RT
  leaves are serialized to doubles, and precision may be lost.
  ParseArg methods now understand either format.
- A wrapper has been added for Aff_transformation_2.
- A wrapper has been added for the global collinear function.
- A coordinate accesser has been added to the Polygon_2 wrapper.
- tavis.yml has been modified so travis will matrix build with both
  the epick and epeck kernels for acceptance testing.
- binding.gyp has ben modified to explicitly build with libc++ under
  OSX, in order to address some dynamic linkage issues surrounding
  use of CGAL stream operators in "pretty" mode.
- A first pass has been made at making commentary and header
  formatting more consistent.
