### PR TITLE
Reduce client project build churn

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "scripts/test",
-    "preinstall": "node-gyp configure && node-gyp build -j 4",
+    "preinstall": "scripts/preinstall",
     "clean": "node-gyp clean && rm -rf build"
   },
   "engines": {

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -1,0 +1,5 @@
+#!/bin/bash -x
+if [[ !(-e build/Makefile) || (binding.gyp -nt build/Makefile) ]]; then
+    node-gyp configure
+fi
+node-gyp build -j 4

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 if [[ !(-e build/Makefile) || (binding.gyp -nt build/Makefile) ]]; then
     node-gyp configure
 fi


### PR DESCRIPTION
We were already using a preinstall script to work around npm's
default behavior of always forcing a "node-gyp rebuild" for modules
that contain a binding.gyp.  Instead, we were doing a "node-gyp
configure" followed by a "node-gyp build".  While this avoided
redundant compilation (the generated Makefile does the right thing),
the timestamps on the Makefile were still being updated by "node-gyp
configure" even though the contents of the Makefile were unchanged.
This was causing extra work to occur in downstream make rules in
some client projects.

Here we bust out the preinstall step to a separate script, and
further elaborate it with logic to skip the "node-gyp configure"
unless the Makefile is missing or out of date wrt. the binding.gyp.
