### PR TITLE
Upgrade to CGAL-4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ node_js:
 before_install:
   - sudo apt-get update -q
   - sudo apt-get install -q libgmp-dev libmpfr-dev libboost-all-dev
-  - curl https://gforge.inria.fr/frs/download.php/33525/CGAL-4.4.tar.gz | tar zxv
-  - (cd CGAL-4.4; CXXFLAGS=-fPIC cmake -DBUILD_SHARED_LIBS=FALSE .; make CGAL)
+  - curl https://gforge.inria.fr/frs/download.php/33525/CGAL-4.5.tar.gz | tar zxv
+  - (cd CGAL-4.5; CXXFLAGS=-fPIC cmake -DBUILD_SHARED_LIBS=FALSE .; make CGAL)
 env:
   global:
-    CGAL_GYP_LDFLAGS: -L$TRAVIS_BUILD_DIR/CGAL-4.4/lib
-    CGAL_GYP_INCLUDES: $TRAVIS_BUILD_DIR/CGAL-4.4/include
+    CGAL_GYP_LDFLAGS: -L$TRAVIS_BUILD_DIR/CGAL-4.5/lib
+    CGAL_GYP_INCLUDES: $TRAVIS_BUILD_DIR/CGAL-4.5/include
   matrix:
     -
     - GGAL_USE_EPECK=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_install:
   - sudo apt-get update -q
   - sudo apt-get install -q libgmp-dev libmpfr-dev libboost-all-dev
-  - curl https://gforge.inria.fr/frs/download.php/33525/CGAL-4.5.tar.gz | tar zxv
+  - curl https://gforge.inria.fr/frs/download.php/file/34149/CGAL-4.5.tar.gz | tar zxv
   - (cd CGAL-4.5; CXXFLAGS=-fPIC cmake -DBUILD_SHARED_LIBS=FALSE .; make CGAL)
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A node.js module providing access to parts of the CGAL computational geometry li
 - Prerequisite: you will need to have the CGAL libraries and headers installed on your build and
 test machines for this.  CGAL sources can be downloaded from cgal.org, and built and installed by
 following the directions there.  This release has been developed and tested against CGAL release
-4.4.
+4.5.
 
 - To install and test locally, do "npm install", and "npm test" in this directory.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cgal",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "CGAL bindings for node.js",
   "keywords": [
     "CGAL",


### PR DESCRIPTION
CGAL 4.5 didn't introduce any breaking changes.  This just updates Travis CI to run against 4.5, and also updates the modules' node version number and README.md.
