### PR TITLE
Port up to Node 5.0.0 and CGAL 4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
+sudo: required
+dist: trusty
 language: node_js
 node_js:
-  - "0.10"
+  - 5.0.0
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+    - libmpfr-dev
+    - libboost-all-dev
 before_install:
-  - sudo apt-get update -q
-  - sudo apt-get install -q libgmp-dev libmpfr-dev libboost-all-dev
-  - curl https://gforge.inria.fr/frs/download.php/33525/CGAL-4.4.tar.gz | tar zxv
-  - (cd CGAL-4.4; CXXFLAGS=-fPIC cmake -DBUILD_SHARED_LIBS=FALSE .; make CGAL)
+  - curl -L https://github.com/CGAL/cgal/archive/releases/CGAL-4.7.tar.gz | tar zx
+  - mkdir $TRAVIS_BUILD_DIR/cgal-releases-CGAL-4.7/installed
+  - (cd cgal-releases-CGAL-4.7; CXXFLAGS=-fPIC cmake -DBUILD_SHARED_LIBS=FALSE -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/cgal-releases-CGAL-4.7/installed .; make install)
 env:
   global:
-    CGAL_GYP_LDFLAGS: -L$TRAVIS_BUILD_DIR/CGAL-4.4/lib
-    CGAL_GYP_INCLUDES: $TRAVIS_BUILD_DIR/CGAL-4.4/include
+    CGAL_GYP_LDFLAGS: -L$TRAVIS_BUILD_DIR/cgal-releases-CGAL-4.7/installed/lib
+    CGAL_GYP_INCLUDES: $TRAVIS_BUILD_DIR/cgal-releases-CGAL-4.7/installed/include
   matrix:
     -
     - GGAL_USE_EPECK=1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A node.js module providing access to parts of the CGAL computational geometry li
 - Prerequisite: you will need to have the CGAL libraries and headers installed on your build and
 test machines for this.  CGAL sources can be downloaded from cgal.org, and built and installed by
 following the directions there.  This release has been developed and tested against CGAL release
-4.4.
+4.7.
 
 - To install and test locally, do "npm install", and "npm test" in this directory.
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -36,7 +36,7 @@
                     'GCC_ENABLE_CPP_RTTI': 'YES',
                     'OTHER_CPLUSPLUSFLAGS': [
                         '-Wno-unneeded-internal-declaration',
-                        '-mmacosx-version-min=10.7',
+                        '-mmacosx-version-min=10.11',
                         '-stdlib=libc++',
                         '<!@(echo $CGAL_GYP_CXXFLAGS)'
                      ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cgal",
-  "version": "4.4.0",
+  "version": "4.7.0",
   "description": "CGAL bindings for node.js",
   "keywords": [
     "CGAL",
@@ -18,7 +18,7 @@
     "clean": "node-gyp clean && rm -rf build"
   },
   "engines": {
-    "node": ">=0.10.7"
+    "node": ">=5.0.0"
   },
   "os": [ "darwin", "linux" ],
   "cpu": [ "x64" ]

--- a/src/AffTransformation2.cc
+++ b/src/AffTransformation2.cc
@@ -10,14 +10,16 @@ using namespace std;
 const char *AffTransformation2::Name = "AffTransformation2";
 
 
-void AffTransformation2::RegisterMethods()
+void AffTransformation2::RegisterMethods(v8::Isolate *isolate)
 {
 }
 
 
-bool AffTransformation2::ParseArg(Local<Value> arg, Aff_transformation_2 &receiver)
+bool AffTransformation2::ParseArg(Isolate *isolate, Local<Value> arg, Aff_transformation_2 &receiver)
 {
-    if (sConstructorTemplate->HasInstance(arg)) {
+    HandleScope scope(isolate);
+
+    if (sConstructorTemplate.Get(isolate)->HasInstance(arg)) {
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
     }
@@ -28,14 +30,14 @@ bool AffTransformation2::ParseArg(Local<Value> arg, Aff_transformation_2 &receiv
         if (inits->Length() >= 6 && inits->Length() <= 7) {
 
             K::RT m00, m01, m02, m10, m11, m12, hw(1);
-            if (::ParseArg(inits->Get(0), m00) &&
-                ::ParseArg(inits->Get(1), m01) &&
-                ::ParseArg(inits->Get(2), m02) &&
-                ::ParseArg(inits->Get(3), m10) &&
-                ::ParseArg(inits->Get(4), m11) &&
-                ::ParseArg(inits->Get(5), m12))
+            if (::ParseArg(isolate, inits->Get(0), m00) &&
+                ::ParseArg(isolate, inits->Get(1), m01) &&
+                ::ParseArg(isolate, inits->Get(2), m02) &&
+                ::ParseArg(isolate, inits->Get(3), m10) &&
+                ::ParseArg(isolate, inits->Get(4), m11) &&
+                ::ParseArg(isolate, inits->Get(5), m12))
             {
-                if ((inits->Length() == 7) && !::ParseArg(inits->Get(6), hw))
+                if ((inits->Length() == 7) && !::ParseArg(isolate, inits->Get(6), hw))
                     return false;
 
                 receiver = Aff_transformation_2(m00, m01, m02, m10, m11, m12, hw);
@@ -48,10 +50,10 @@ bool AffTransformation2::ParseArg(Local<Value> arg, Aff_transformation_2 &receiv
 
             Direction_2 dir;
             K::RT num, den(1);
-            if (Direction2::ParseArg(inits->Get(0), dir) &&
-                ::ParseArg(inits->Get(1), num))
+            if (Direction2::ParseArg(isolate, inits->Get(0), dir) &&
+                ::ParseArg(isolate, inits->Get(1), num))
             {
-                if ((inits->Length() == 3) && !::ParseArg(inits->Get(2), den))
+                if ((inits->Length() == 3) && !::ParseArg(isolate, inits->Get(2), den))
                     return false;
 
                 receiver = Aff_transformation_2(Rotation(), dir, num, den);
@@ -66,10 +68,10 @@ bool AffTransformation2::ParseArg(Local<Value> arg, Aff_transformation_2 &receiv
 }
 
 
-Handle<Value> AffTransformation2::ToPOD(const Aff_transformation_2 &aff, bool precise)
+Local<Value> AffTransformation2::ToPOD(Isolate *isolate, const Aff_transformation_2 &aff, bool precise)
 {
-    HandleScope scope;
-    Local<Array> array = Array::New(7);
+    EscapableHandleScope scope(isolate);
+    Local<Array> array = Array::New(isolate, 7);
 
     try {
         for(int i=0; i<7; ++i) {
@@ -83,17 +85,17 @@ Handle<Value> AffTransformation2::ToPOD(const Aff_transformation_2 &aff, bool pr
 #else
                 str << a;
 #endif
-                array->Set(i, String::New(str.str().c_str()));
+                array->Set(i, String::NewFromUtf8(isolate, str.str().c_str()));
             } else {
-                array->Set(i, Number::New(CGAL::to_double(a)));
+                array->Set(i, Number::New(isolate, CGAL::to_double(a)));
             }
         }
     }
 
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 
-    return scope.Close(array);
+    return scope.Escape(array);
 }
 

--- a/src/AffTransformation2.h
+++ b/src/AffTransformation2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Aff_transformation_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Aff_transformation_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Aff_transformation_2 &aff, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Aff_transformation_2 &aff, bool precise=true);
 
 private:
 

--- a/src/Arrangement2.cc
+++ b/src/Arrangement2.cc
@@ -16,49 +16,51 @@ using namespace std;
 const char *Arrangement2::Name = "Arrangement2";
 
 
-void Arrangement2::RegisterMethods()
+void Arrangement2::RegisterMethods(Isolate *isolate)
 {
-    SetPrototypeMethod(sConstructorTemplate, "toString", ToString);
-    SetPrototypeMethod(sConstructorTemplate, "clear", Clear);
-    SetPrototypeMethod(sConstructorTemplate, "isEmpty", IsEmpty);
-    SetPrototypeMethod(sConstructorTemplate, "isValid", IsValid);
-    SetPrototypeMethod(sConstructorTemplate, "insert", Insert);
-    SetPrototypeMethod(sConstructorTemplate, "insertLines", InsertLines); // deprecated
-    SetPrototypeMethod(sConstructorTemplate, "numberOfVertices", NumberOfVertices);
-    SetPrototypeMethod(sConstructorTemplate, "numberOfIsolatedVertices", NumberOfIsolatedVertices);
-    SetPrototypeMethod(sConstructorTemplate, "vertices", Vertices);
-    SetPrototypeMethod(sConstructorTemplate, "numberOfVerticesAtInfinity", NumberOfVerticesAtInfinity);
-    SetPrototypeMethod(sConstructorTemplate, "unboundedFace", UnboundedFace);
-    SetPrototypeMethod(sConstructorTemplate, "numberOfFaces", NumberOfFaces);
-    SetPrototypeMethod(sConstructorTemplate, "faces", Faces);
-    SetPrototypeMethod(sConstructorTemplate, "numberOfUnboundedFaces", NumberOfUnboundedFaces);
-    SetPrototypeMethod(sConstructorTemplate, "unboundedFaces", UnboundedFaces);
-    SetPrototypeMethod(sConstructorTemplate, "fictitiousFace", FictitiousFace);
-    SetPrototypeMethod(sConstructorTemplate, "numberOfHalfedges", NumberOfHalfedges);
-    SetPrototypeMethod(sConstructorTemplate, "halfedges", Halfedges);
-    SetPrototypeMethod(sConstructorTemplate, "numberOfEdges", NumberOfEdges);
-    SetPrototypeMethod(sConstructorTemplate, "edges", Edges);
-    SetPrototypeMethod(sConstructorTemplate, "insertInFaceInterior", InsertInFaceInterior);
-    SetPrototypeMethod(sConstructorTemplate, "insertFromLeftVertex", InsertFromLeftVertex);
-    SetPrototypeMethod(sConstructorTemplate, "insertFromRightVertex", InsertFromRightVertex);
-    SetPrototypeMethod(sConstructorTemplate, "insertAtVertices", InsertAtVertices);
-    SetPrototypeMethod(sConstructorTemplate, "modifyVertex", ModifyVertex);
-    SetPrototypeMethod(sConstructorTemplate, "removeIsolatedVertex", RemoveIsolatedVertex);
-    SetPrototypeMethod(sConstructorTemplate, "modifyEdge", ModifyEdge);
-    SetPrototypeMethod(sConstructorTemplate, "splitEdge", SplitEdge);
-    SetPrototypeMethod(sConstructorTemplate, "mergeEdge", MergeEdge);
-    SetPrototypeMethod(sConstructorTemplate, "removeEdge", RemoveEdge);
-    SetPrototypeMethod(sConstructorTemplate, "removeEdgeAndMerge", RemoveEdgeAndMerge);
+    HandleScope scope(isolate);
+    Local<FunctionTemplate> constructorTemplate = sConstructorTemplate.Get(isolate);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "toString", ToString);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "clear", Clear);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isEmpty", IsEmpty);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isValid", IsValid);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "insert", Insert);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "insertLines", InsertLines); // deprecated
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "numberOfVertices", NumberOfVertices);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "numberOfIsolatedVertices", NumberOfIsolatedVertices);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "vertices", Vertices);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "numberOfVerticesAtInfinity", NumberOfVerticesAtInfinity);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "unboundedFace", UnboundedFace);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "numberOfFaces", NumberOfFaces);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "faces", Faces);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "numberOfUnboundedFaces", NumberOfUnboundedFaces);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "unboundedFaces", UnboundedFaces);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "fictitiousFace", FictitiousFace);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "numberOfHalfedges", NumberOfHalfedges);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "halfedges", Halfedges);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "numberOfEdges", NumberOfEdges);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "edges", Edges);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "insertInFaceInterior", InsertInFaceInterior);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "insertFromLeftVertex", InsertFromLeftVertex);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "insertFromRightVertex", InsertFromRightVertex);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "insertAtVertices", InsertAtVertices);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "modifyVertex", ModifyVertex);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "removeIsolatedVertex", RemoveIsolatedVertex);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "modifyEdge", ModifyEdge);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "splitEdge", SplitEdge);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "mergeEdge", MergeEdge);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "removeEdge", RemoveEdge);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "removeEdgeAndMerge", RemoveEdgeAndMerge);
 
-    Arrangement2Face::Init(sConstructorTemplate);
-    Arrangement2Halfedge::Init(sConstructorTemplate);
-    Arrangement2Vertex::Init(sConstructorTemplate);
+    Arrangement2Face::Init(constructorTemplate);
+    Arrangement2Halfedge::Init(constructorTemplate);
+    Arrangement2Vertex::Init(constructorTemplate);
 }
 
 
-bool Arrangement2::ParseArg(Local<Value> arg, Arrangement_2 &receiver)
+bool Arrangement2::ParseArg(Isolate *isolate, Local<Value> arg, Arrangement_2 &receiver)
 {
-    if (sConstructorTemplate->HasInstance(arg)) {
+    if (sConstructorTemplate.Get(isolate)->HasInstance(arg)) {
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
     }
@@ -67,19 +69,22 @@ bool Arrangement2::ParseArg(Local<Value> arg, Arrangement_2 &receiver)
 }
 
 
-Handle<Value> Arrangement2::ToPOD(const Arrangement_2 &arrangement, bool precise)
+Local<Value> Arrangement2::ToPOD(Isolate *isolate, const Arrangement_2 &arrangement, bool precise)
 {
-    HandleScope scope;
-    Local<Object> obj = Object::New();
-    obj->Set(String::NewSymbol("numFaces"), Number::New(arrangement.number_of_faces()));
-    obj->Set(String::NewSymbol("numUnboundedFaces"),
-        Number::New(arrangement.number_of_unbounded_faces()));
-    obj->Set(String::NewSymbol("numBoundedFaces"),
-        Number::New(arrangement.number_of_faces()-arrangement.number_of_unbounded_faces()));
-    obj->Set(String::NewSymbol("numVertices"), Number::New(arrangement.number_of_vertices()));
+    EscapableHandleScope scope(isolate);
 
-    Local<Array> faceArray = Array::New();
-    obj->Set(String::NewSymbol("boundedFaces"), faceArray);
+    Local<Object> obj = Object::New(isolate);
+    obj->Set(SYMBOL(isolate, "numFaces"),
+        Number::New(isolate, arrangement.number_of_faces()));
+    obj->Set(SYMBOL(isolate, "numUnboundedFaces"),
+        Number::New(isolate, arrangement.number_of_unbounded_faces()));
+    obj->Set(SYMBOL(isolate, "numBoundedFaces"),
+        Number::New(isolate, arrangement.number_of_faces()-arrangement.number_of_unbounded_faces()));
+    obj->Set(SYMBOL(isolate, "numVertices"),
+        Number::New(isolate, arrangement.number_of_vertices()));
+
+    Local<Array> faceArray = Array::New(isolate);
+    obj->Set(SYMBOL(isolate, "boundedFaces"), faceArray);
 
     // POD-ify arrangement faces and assign to array within object.
     Arrangement_2::Face_const_iterator fit;
@@ -96,653 +101,733 @@ Handle<Value> Arrangement2::ToPOD(const Arrangement_2 &arrangement, bool precise
             do { *bit++  = curr->source()->point(); } while (++curr != circ);
 
             // Add poly created from edge source points to face array.
-            faceArray->Set(faceNum, Polygon2::ToPOD(poly, precise));
+            faceArray->Set(faceNum, Polygon2::ToPOD(isolate, poly, precise));
             faceNum++;
         }
     }
 
-    return scope.Close(obj);
+    return scope.Escape(obj);
 }
 
 
-Handle<Value> Arrangement2::ToString(const v8::Arguments &args)
+void Arrangement2::ToString(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
-    Arrangement_2 &arrangement = ExtractWrapped(args.This());
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
+    Arrangement_2 &arrangement = ExtractWrapped(info.This());
     ostringstream str;
     str << "[object "  << Name << " " << &arrangement << " ";
     str << "F:" << arrangement.number_of_faces() << " ";
     str << "V:" << arrangement.number_of_vertices() << " ";
     str << "E:" << arrangement.number_of_edges() << "]";
-    return scope.Close(String::New(str.str().c_str()));
+    info.GetReturnValue().Set(String::NewFromUtf8(isolate, str.str().c_str()));
 }
 
 
-Handle<Value> Arrangement2::Clear(const Arguments &args)
+void Arrangement2::Clear(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
         arrangement.clear();
-        return Undefined();
+        info.GetReturnValue().SetUndefined();
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::IsEmpty(const Arguments &args)
+void Arrangement2::IsEmpty(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(arrangement.is_empty()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, arrangement.is_empty()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::IsValid(const Arguments &args)
+void Arrangement2::IsValid(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(arrangement.is_valid()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, arrangement.is_valid()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::Insert(const v8::Arguments &args)
+void Arrangement2::Insert(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
 
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
 
-        ARGS_ASSERT(args.Length() == 1);
+        ARGS_ASSERT(isolate, info.Length() == 1);
 
-        if (args[0]->IsArray()) {
+        if (info[0]->IsArray()) {
             std::vector<Curve_2> curves;
-            Curve2::ParseSeqArg(args[0], back_inserter(curves));
+            Curve2::ParseSeqArg(isolate, info[0], back_inserter(curves));
             insert(arrangement, curves.begin(), curves.end());
-            return Undefined();
+            info.GetReturnValue().SetUndefined();
+            return;
         }
 
         Curve_2 curve;
-        if (Curve2::ParseArg(args[0], curve)) {
+        if (Curve2::ParseArg(isolate, info[0], curve)) {
             insert(arrangement, curve);
-            return Undefined();
+            info.GetReturnValue().SetUndefined();
         }
 
-        ARGS_ASSERT(false);
+        ARGS_ASSERT(isolate, false);
 
     }
 
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 
 }
 
 
-Handle<Value> Arrangement2::InsertLines(const Arguments &args)
+void Arrangement2::InsertLines(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
 
     // InsertLines expects to be called with an array of Line2 objects.
-    ARGS_ASSERT(args[0]->IsArray());
+    ARGS_ASSERT(isolate, info[0]->IsArray());
 
     try {
 
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
 
-        Local<Array> lines = Local<Array>::Cast(args[0]);
+        Local<Array> lines = Local<Array>::Cast(info[0]);
         for(uint32_t i=0; i<lines->Length(); ++i) {
-            ARGS_PARSE_LOCAL(Line2::ParseArg, Line_2, line, lines->Get(i));
+            ARGS_PARSE_LOCAL(isolate, Line2::ParseArg, Line_2, line, lines->Get(i));
             CGAL::insert(arrangement, line);
         }
-        return Undefined();
+
+        info.GetReturnValue().SetUndefined();
 
     }
 
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 
 }
 
 
-Handle<Value> Arrangement2::NumberOfVertices(const Arguments &args)
+void Arrangement2::NumberOfVertices(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Number::New(arrangement.number_of_vertices()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, arrangement.number_of_vertices()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::NumberOfIsolatedVertices(const Arguments &args)
+void Arrangement2::NumberOfIsolatedVertices(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Number::New(arrangement.number_of_isolated_vertices()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, arrangement.number_of_isolated_vertices()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::Vertices(const Arguments &args)
+void Arrangement2::Vertices(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        Local<Array> array = Array::New();
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        Local<Array> array = Array::New(isolate);
         Arrangement_2::Vertex_iterator it;
         uint32_t i;
         for(it=arrangement.vertices_begin(),i=0; it!=arrangement.vertices_end(); ++it,++i) {
-            array->Set(i, Arrangement2Vertex::New(it));
+            array->Set(i, Arrangement2Vertex::New(isolate, it));
         }
-        return scope.Close(array);
+        info.GetReturnValue().Set(array);
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::NumberOfVerticesAtInfinity(const Arguments &args)
+void Arrangement2::NumberOfVerticesAtInfinity(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Number::New(arrangement.number_of_vertices_at_infinity()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, arrangement.number_of_vertices_at_infinity()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::UnboundedFace(const Arguments &args)
+void Arrangement2::UnboundedFace(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Arrangement2Face::New(arrangement.unbounded_face()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Arrangement2Face::New(isolate, arrangement.unbounded_face()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::NumberOfFaces(const Arguments &args)
+void Arrangement2::NumberOfFaces(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Number::New(arrangement.number_of_faces()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, arrangement.number_of_faces()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::Faces(const Arguments &args)
+void Arrangement2::Faces(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        Local<Array> array = Array::New();
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        Local<Array> array = Array::New(isolate);
         Arrangement_2::Face_iterator it;
         uint32_t i;
         for(it=arrangement.faces_begin(),i=0; it!=arrangement.faces_end(); ++it,++i) {
-            array->Set(i, Arrangement2Face::New(it));
+            array->Set(i, Arrangement2Face::New(isolate, it));
         }
-        return scope.Close(array);
+        info.GetReturnValue().Set(array);
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::NumberOfUnboundedFaces(const Arguments &args)
+void Arrangement2::NumberOfUnboundedFaces(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Number::New(arrangement.number_of_unbounded_faces()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, arrangement.number_of_unbounded_faces()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::UnboundedFaces(const Arguments &args)
+void Arrangement2::UnboundedFaces(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        Local<Array> array = Array::New();
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        Local<Array> array = Array::New(isolate);
         Arrangement_2::Face_iterator it;
         uint32_t i;
         for(it=arrangement.unbounded_faces_begin(),i=0; it!=arrangement.unbounded_faces_end(); ++it,++i) {
-            array->Set(i, Arrangement2Face::New(it));
+            array->Set(i, Arrangement2Face::New(isolate, it));
         }
-        return scope.Close(array);
+        info.GetReturnValue().Set(array);
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::FictitiousFace(const Arguments &args)
+void Arrangement2::FictitiousFace(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Arrangement2Face::New(arrangement.fictitious_face()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Arrangement2Face::New(isolate, arrangement.fictitious_face()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::NumberOfHalfedges(const Arguments &args)
+void Arrangement2::NumberOfHalfedges(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Number::New(arrangement.number_of_halfedges()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, arrangement.number_of_halfedges()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::Halfedges(const Arguments &args)
+void Arrangement2::Halfedges(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        Local<Array> array = Array::New();
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        Local<Array> array = Array::New(isolate);
         Arrangement_2::Halfedge_iterator it;
         uint32_t i;
         for(it=arrangement.halfedges_begin(),i=0; it!=arrangement.halfedges_end(); ++it,++i) {
-            array->Set(i, Arrangement2Halfedge::New(it));
+            array->Set(i, Arrangement2Halfedge::New(isolate, it));
         }
-        return scope.Close(array);
+        info.GetReturnValue().Set(array);
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::NumberOfEdges(const Arguments &args)
+void Arrangement2::NumberOfEdges(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        return scope.Close(Number::New(arrangement.number_of_edges()));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, arrangement.number_of_edges()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::Edges(const Arguments &args)
+void Arrangement2::Edges(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        Local<Array> array = Array::New();
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        Local<Array> array = Array::New(isolate);
         Arrangement_2::Halfedge_iterator it;
         uint32_t i;
         for(it=arrangement.edges_begin(),i=0; it!=arrangement.edges_end(); ++it,++i) {
-            array->Set(i, Arrangement2Halfedge::New(it));
+            array->Set(i, Arrangement2Halfedge::New(isolate, it));
         }
-        return scope.Close(array);
+        info.GetReturnValue().Set(array);
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::InsertInFaceInterior(const v8::Arguments &args)
+void Arrangement2::InsertInFaceInterior(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
 
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
 
         Point_2 point;
         Arrangement_2::Face_handle face;
         Curve_2 curve;
 
-        if ((args.Length() == 2)
-            && Point2::ParseArg(args[0], point)
-            && Arrangement2Face::ParseArg(args[1], face))
+        if ((info.Length() == 2)
+            && Point2::ParseArg(isolate, info[0], point)
+            && Arrangement2Face::ParseArg(isolate, info[1], face))
         {
-            return scope.Close(Arrangement2Vertex::New(arrangement.insert_in_face_interior(point, face)));
+            info.GetReturnValue().Set(
+                Arrangement2Vertex::New(isolate, arrangement.insert_in_face_interior(point, face))
+            );
+            return;
         }
 
-        if ((args.Length() == 2)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Face::ParseArg(args[1], face))
+        if ((info.Length() == 2)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Face::ParseArg(isolate, info[1], face))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_in_face_interior(curve, face)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_in_face_interior(curve, face))
+            );
+            return;
         }
 
-        ARGS_ASSERT(false);
+        ARGS_ASSERT(isolate, false);
 
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::InsertFromLeftVertex(const v8::Arguments &args)
+void Arrangement2::InsertFromLeftVertex(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
 
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
 
         Curve_2 curve;
         Arrangement_2::Vertex_handle vertex;
         Arrangement_2::Face_handle face;
         Arrangement_2::Halfedge_handle edge;
 
-        if ((args.Length() == 2)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Vertex::ParseArg(args[1], vertex))
+        if ((info.Length() == 2)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Vertex::ParseArg(isolate, info[1], vertex))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_left_vertex(curve, vertex)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_from_left_vertex(curve, vertex))
+            );
+            return;
         }
 
-        if ((args.Length() == 3)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Vertex::ParseArg(args[1], vertex)
-            && Arrangement2Face::ParseArg(args[2], face))
+        if ((info.Length() == 3)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Vertex::ParseArg(isolate, info[1], vertex)
+            && Arrangement2Face::ParseArg(isolate, info[2], face))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_left_vertex(curve, vertex, face)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_from_left_vertex(curve, vertex, face))
+            );
+            return;
         }
 
-        if ((args.Length() == 2)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Halfedge::ParseArg(args[1], edge))
+        if ((info.Length() == 2)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Halfedge::ParseArg(isolate, info[1], edge))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_left_vertex(curve, edge)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_from_left_vertex(curve, edge))
+            );
+            return;
         }
 
-        ARGS_ASSERT(false);
+        ARGS_ASSERT(isolate, false);
 
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::InsertFromRightVertex(const v8::Arguments &args)
+void Arrangement2::InsertFromRightVertex(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
 
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
 
         Curve_2 curve;
         Arrangement_2::Vertex_handle vertex;
         Arrangement_2::Face_handle face;
         Arrangement_2::Halfedge_handle edge;
 
-        if ((args.Length() == 2)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Vertex::ParseArg(args[1], vertex))
+        if ((info.Length() == 2)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Vertex::ParseArg(isolate, info[1], vertex))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_right_vertex(curve, vertex)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_from_right_vertex(curve, vertex))
+            );
+            return;
         }
 
-        if ((args.Length() == 3)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Vertex::ParseArg(args[1], vertex)
-            && Arrangement2Face::ParseArg(args[2], face))
+        if ((info.Length() == 3)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Vertex::ParseArg(isolate, info[1], vertex)
+            && Arrangement2Face::ParseArg(isolate, info[2], face))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_right_vertex(curve, vertex, face)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_from_right_vertex(curve, vertex, face))
+            );
+            return;
         }
 
-        if ((args.Length() == 2)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Halfedge::ParseArg(args[1], edge))
+        if ((info.Length() == 2)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Halfedge::ParseArg(isolate, info[1], edge))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_from_right_vertex(curve, edge)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_from_right_vertex(curve, edge))
+            );
+            return;
         }
 
-        ARGS_ASSERT(false);
+        ARGS_ASSERT(isolate, false);
 
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::InsertAtVertices(const v8::Arguments &args)
+void Arrangement2::InsertAtVertices(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
 
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
 
         Curve_2 curve;
         Arrangement_2::Vertex_handle vertex1, vertex2;
         Arrangement_2::Face_handle face;
         Arrangement_2::Halfedge_handle edge1, edge2;
 
-        if ((args.Length() == 3)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Vertex::ParseArg(args[1], vertex1)
-            && Arrangement2Vertex::ParseArg(args[2], vertex2))
+        if ((info.Length() == 3)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Vertex::ParseArg(isolate, info[1], vertex1)
+            && Arrangement2Vertex::ParseArg(isolate, info[2], vertex2))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_at_vertices(curve, vertex1, vertex2)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_at_vertices(curve, vertex1, vertex2))
+            );
+            return;
         }
 
-        if ((args.Length() == 4)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Vertex::ParseArg(args[1], vertex1)
-            && Arrangement2Vertex::ParseArg(args[2], vertex2)
-            && Arrangement2Face::ParseArg(args[3], face))
+        if ((info.Length() == 4)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Vertex::ParseArg(isolate, info[1], vertex1)
+            && Arrangement2Vertex::ParseArg(isolate, info[2], vertex2)
+            && Arrangement2Face::ParseArg(isolate, info[3], face))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_at_vertices(curve, vertex1, vertex2, face)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_at_vertices(curve, vertex1, vertex2, face))
+            );
+            return;
         }
 
-        if ((args.Length() == 3)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Halfedge::ParseArg(args[1], edge1)
-            && Arrangement2Vertex::ParseArg(args[2], vertex1))
+        if ((info.Length() == 3)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Halfedge::ParseArg(isolate, info[1], edge1)
+            && Arrangement2Vertex::ParseArg(isolate, info[2], vertex1))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_at_vertices(curve, edge1, vertex1)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_at_vertices(curve, edge1, vertex1))
+            );
+            return;
         }
 
-        if ((args.Length() == 3)
-            && Curve2::ParseArg(args[0], curve)
-            && Arrangement2Halfedge::ParseArg(args[1], edge1)
-            && Arrangement2Halfedge::ParseArg(args[2], edge1))
+        if ((info.Length() == 3)
+            && Curve2::ParseArg(isolate, info[0], curve)
+            && Arrangement2Halfedge::ParseArg(isolate, info[1], edge1)
+            && Arrangement2Halfedge::ParseArg(isolate, info[2], edge1))
         {
-            return scope.Close(Arrangement2Halfedge::New(arrangement.insert_at_vertices(curve, edge1, edge2)));
+            info.GetReturnValue().Set(
+                Arrangement2Halfedge::New(isolate, arrangement.insert_at_vertices(curve, edge1, edge2))
+            );
+            return;
         }
 
-        ARGS_ASSERT(false);
+        ARGS_ASSERT(isolate, false);
 
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::ModifyVertex(const v8::Arguments &args)
+void Arrangement2::ModifyVertex(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 2);
-        ARGS_PARSE_LOCAL(Arrangement2Vertex::ParseArg, Arrangement_2::Vertex_handle, vertex, args[0]);
-        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, point, args[1]);
-        return scope.Close(Arrangement2Vertex::New(arrangement.modify_vertex(vertex, point)));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 2);
+        ARGS_PARSE_LOCAL(isolate, Arrangement2Vertex::ParseArg, Arrangement_2::Vertex_handle, vertex, info[0]);
+        ARGS_PARSE_LOCAL(isolate, Point2::ParseArg, Point_2, point, info[1]);
+        info.GetReturnValue().Set(Arrangement2Vertex::New(isolate, arrangement.modify_vertex(vertex, point)));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::RemoveIsolatedVertex(const v8::Arguments &args)
+void Arrangement2::RemoveIsolatedVertex(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Arrangement2Vertex::ParseArg, Arrangement_2::Vertex_handle, vertex, args[0]);
-        return scope.Close(Arrangement2Face::New(arrangement.remove_isolated_vertex(vertex)));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Arrangement2Vertex::ParseArg, Arrangement_2::Vertex_handle, vertex, info[0]);
+        info.GetReturnValue().Set(Arrangement2Face::New(isolate, arrangement.remove_isolated_vertex(vertex)));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::ModifyEdge(const v8::Arguments &args)
+void Arrangement2::ModifyEdge(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 2);
-        ARGS_PARSE_LOCAL(Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge, args[0]);
-        ARGS_PARSE_LOCAL(Curve2::ParseArg, Curve_2, curve, args[1]);
-        return scope.Close(Arrangement2Halfedge::New(arrangement.modify_edge(halfedge, curve)));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 2);
+        ARGS_PARSE_LOCAL(isolate, Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge, info[0]);
+        ARGS_PARSE_LOCAL(isolate, Curve2::ParseArg, Curve_2, curve, info[1]);
+        info.GetReturnValue().Set(Arrangement2Halfedge::New(isolate, arrangement.modify_edge(halfedge, curve)));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::SplitEdge(const v8::Arguments &args)
+void Arrangement2::SplitEdge(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 3);
-        ARGS_PARSE_LOCAL(Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge, args[0]);
-        ARGS_PARSE_LOCAL(Curve2::ParseArg, Curve_2, curve1, args[1]);
-        ARGS_PARSE_LOCAL(Curve2::ParseArg, Curve_2, curve2, args[2]);
-        return scope.Close(Arrangement2Halfedge::New(arrangement.split_edge(halfedge, curve1, curve2)));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 3);
+        ARGS_PARSE_LOCAL(isolate, Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge, info[0]);
+        ARGS_PARSE_LOCAL(isolate, Curve2::ParseArg, Curve_2, curve1, info[1]);
+        ARGS_PARSE_LOCAL(isolate, Curve2::ParseArg, Curve_2, curve2, info[2]);
+        info.GetReturnValue().Set(Arrangement2Halfedge::New(isolate, arrangement.split_edge(halfedge, curve1, curve2)));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::MergeEdge(const v8::Arguments &args)
+void Arrangement2::MergeEdge(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 3);
-        ARGS_PARSE_LOCAL(Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge1, args[0]);
-        ARGS_PARSE_LOCAL(Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge2, args[1]);
-        ARGS_PARSE_LOCAL(Curve2::ParseArg, Curve_2, curve, args[2]);
-        return scope.Close(Arrangement2Halfedge::New(arrangement.merge_edge(halfedge1, halfedge2, curve)));
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 3);
+        ARGS_PARSE_LOCAL(isolate, Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge1, info[0]);
+        ARGS_PARSE_LOCAL(isolate, Arrangement2Halfedge::ParseArg, Arrangement_2::Halfedge_handle, halfedge2, info[1]);
+        ARGS_PARSE_LOCAL(isolate, Curve2::ParseArg, Curve_2, curve, info[2]);
+        info.GetReturnValue().Set(Arrangement2Halfedge::New(isolate, arrangement.merge_edge(halfedge1, halfedge2, curve)));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::RemoveEdge(const v8::Arguments &args)
+void Arrangement2::RemoveEdge(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
 
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
 
         Arrangement_2::Halfedge_handle edge;
 
-        if ((args.Length() == 1)
-            && Arrangement2Halfedge::ParseArg(args[0], edge))
+        if ((info.Length() == 1)
+            && Arrangement2Halfedge::ParseArg(isolate, info[0], edge))
         {
-            return scope.Close(Arrangement2Face::New(arrangement.remove_edge(edge)));
+            info.GetReturnValue().Set(Arrangement2Face::New(isolate, arrangement.remove_edge(edge)));
+            return;
         }
 
-        if ((args.Length() == 2)
-            && Arrangement2Halfedge::ParseArg(args[0], edge)
-            && args[1]->IsBoolean())
+        if ((info.Length() == 2)
+            && Arrangement2Halfedge::ParseArg(isolate, info[0], edge)
+            && info[1]->IsBoolean())
         {
-            return scope.Close(Arrangement2Face::New(arrangement.remove_edge(edge, args[1]->BooleanValue())));
+            info.GetReturnValue().Set(
+                Arrangement2Face::New(isolate, arrangement.remove_edge(edge, info[1]->BooleanValue()))
+            );
+            return;
         }
 
-        if ((args.Length() == 3)
-            && Arrangement2Halfedge::ParseArg(args[0], edge)
-            && args[1]->IsBoolean()
-            && args[2]->IsBoolean())
+        if ((info.Length() == 3)
+            && Arrangement2Halfedge::ParseArg(isolate, info[0], edge)
+            && info[1]->IsBoolean()
+            && info[2]->IsBoolean())
         {
-            return scope.Close(Arrangement2Face::New(arrangement.remove_edge(edge, args[1]->BooleanValue(), args[2]->BooleanValue())));
+            info.GetReturnValue().Set(
+                Arrangement2Face::New(
+                    isolate,
+                    arrangement.remove_edge(edge, info[1]->BooleanValue(), info[2]->BooleanValue())
+                )
+            );
+            return;
         }
 
-        ARGS_ASSERT(false);
+        ARGS_ASSERT(isolate, false);
 
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2::RemoveEdgeAndMerge(const v8::Arguments &args)
+void Arrangement2::RemoveEdgeAndMerge(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
 
-        Arrangement_2 &arrangement = ExtractWrapped(args.This());
+        Arrangement_2 &arrangement = ExtractWrapped(info.This());
 
         Arrangement_2::Halfedge_handle edge;
 
-        if ((args.Length() == 1)
-            && Arrangement2Halfedge::ParseArg(args[0], edge))
+        if ((info.Length() == 1)
+            && Arrangement2Halfedge::ParseArg(isolate, info[0], edge))
         {
-            return scope.Close(Arrangement2Face::New(remove_edge(arrangement, edge)));
+            info.GetReturnValue().Set(Arrangement2Face::New(isolate, remove_edge(arrangement, edge)));
+            return;
         }
 
-        ARGS_ASSERT(false);
+        ARGS_ASSERT(isolate, false);
 
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }

--- a/src/Arrangement2.h
+++ b/src/Arrangement2.h
@@ -16,15 +16,17 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Arrangement_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Arrangement_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Arrangement_2 &Arrangement, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(
+        v8::Isolate *isolate, const Arrangement_2 &Arrangement, bool precise=true
+    );
 
 private:
 
@@ -33,37 +35,37 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> ToString(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Clear(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsEmpty(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsValid(const v8::Arguments &args);
-    static v8::Handle<v8::Value> InsertLines(const v8::Arguments &args); // deprecated
-    static v8::Handle<v8::Value> Insert(const v8::Arguments &args);
-    static v8::Handle<v8::Value> NumberOfVertices(const v8::Arguments &args);
-    static v8::Handle<v8::Value> NumberOfIsolatedVertices(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Vertices(const v8::Arguments &args);
-    static v8::Handle<v8::Value> NumberOfVerticesAtInfinity(const v8::Arguments &args);
-    static v8::Handle<v8::Value> UnboundedFace(const v8::Arguments &args);
-    static v8::Handle<v8::Value> NumberOfFaces(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Faces(const v8::Arguments &args);
-    static v8::Handle<v8::Value> NumberOfUnboundedFaces(const v8::Arguments &args);
-    static v8::Handle<v8::Value> UnboundedFaces(const v8::Arguments &args);
-    static v8::Handle<v8::Value> FictitiousFace(const v8::Arguments &args);
-    static v8::Handle<v8::Value> NumberOfHalfedges(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Halfedges(const v8::Arguments &args);
-    static v8::Handle<v8::Value> NumberOfEdges(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Edges(const v8::Arguments &args);
-    static v8::Handle<v8::Value> InsertInFaceInterior(const v8::Arguments &args);
-    static v8::Handle<v8::Value> InsertFromLeftVertex(const v8::Arguments &args);
-    static v8::Handle<v8::Value> InsertFromRightVertex(const v8::Arguments &args);
-    static v8::Handle<v8::Value> InsertAtVertices(const v8::Arguments &args);
-    static v8::Handle<v8::Value> ModifyVertex(const v8::Arguments &args);
-    static v8::Handle<v8::Value> RemoveIsolatedVertex(const v8::Arguments &args);
-    static v8::Handle<v8::Value> ModifyEdge(const v8::Arguments &args);
-    static v8::Handle<v8::Value> SplitEdge(const v8::Arguments &args);
-    static v8::Handle<v8::Value> MergeEdge(const v8::Arguments &args);
-    static v8::Handle<v8::Value> RemoveEdge(const v8::Arguments &args);
-    static v8::Handle<v8::Value> RemoveEdgeAndMerge(const v8::Arguments &args);
+    static void ToString(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void Clear(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void IsEmpty(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void IsValid(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void InsertLines(const v8::FunctionCallbackInfo<v8::Value> &args); // deprecated
+    static void Insert(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void NumberOfVertices(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void NumberOfIsolatedVertices(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void Vertices(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void NumberOfVerticesAtInfinity(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void UnboundedFace(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void NumberOfFaces(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void Faces(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void NumberOfUnboundedFaces(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void UnboundedFaces(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void FictitiousFace(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void NumberOfHalfedges(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void Halfedges(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void NumberOfEdges(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void Edges(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void InsertInFaceInterior(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void InsertFromLeftVertex(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void InsertFromRightVertex(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void InsertAtVertices(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void ModifyVertex(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void RemoveIsolatedVertex(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void ModifyEdge(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void SplitEdge(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void MergeEdge(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void RemoveEdge(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void RemoveEdgeAndMerge(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 };
 

--- a/src/Arrangement2Face.h
+++ b/src/Arrangement2Face.h
@@ -16,15 +16,17 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Arrangement_2::Face_handle &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Arrangement_2::Face_handle &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Arrangement_2::Face_handle &face, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(
+        v8::Isolate *isolate, const Arrangement_2::Face_handle &face, bool precise=true
+    );
 
 private:
 
@@ -33,12 +35,12 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> ToString(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsFictitious(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsUnbounded(const v8::Arguments &args);
-    static v8::Handle<v8::Value> OuterCCB(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Holes(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsolatedVertices(const v8::Arguments &args);
+    static void ToString(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsFictitious(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsUnbounded(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void OuterCCB(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Holes(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsolatedVertices(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/Arrangement2Halfedge.cc
+++ b/src/Arrangement2Halfedge.cc
@@ -12,24 +12,26 @@ using namespace std;
 const char *Arrangement2Halfedge::Name = "Halfedge";
 
 
-void Arrangement2Halfedge::RegisterMethods()
+void Arrangement2Halfedge::RegisterMethods(Isolate *isolate)
 {
-    SetPrototypeMethod(sConstructorTemplate, "toString", ToString);
-    SetPrototypeMethod(sConstructorTemplate, "isFictitious", IsFictitious);
-    SetPrototypeMethod(sConstructorTemplate, "source", Source);
-    SetPrototypeMethod(sConstructorTemplate, "target", Target);
-    SetPrototypeMethod(sConstructorTemplate, "face", Face);
-    SetPrototypeMethod(sConstructorTemplate, "twin", Twin);
-    SetPrototypeMethod(sConstructorTemplate, "prev", Prev);
-    SetPrototypeMethod(sConstructorTemplate, "next", Next);
-    SetPrototypeMethod(sConstructorTemplate, "ccb", CCB);
-    SetPrototypeMethod(sConstructorTemplate, "curve", Curve);
+    HandleScope scope(isolate);
+    Local<FunctionTemplate> constructorTemplate = sConstructorTemplate.Get(isolate);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "toString", ToString);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isFictitious", IsFictitious);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "source", Source);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "target", Target);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "face", Face);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "twin", Twin);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "prev", Prev);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "next", Next);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "ccb", CCB);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "curve", Curve);
 }
 
 
-bool Arrangement2Halfedge::ParseArg(Local<Value> arg, Arrangement_2::Halfedge_handle &receiver)
+bool Arrangement2Halfedge::ParseArg(Isolate *isolate, Local<Value> arg, Arrangement_2::Halfedge_handle &receiver)
 {
-    if (sConstructorTemplate->HasInstance(arg)) {
+    if (sConstructorTemplate.Get(isolate)->HasInstance(arg)) {
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
     }
@@ -38,147 +40,158 @@ bool Arrangement2Halfedge::ParseArg(Local<Value> arg, Arrangement_2::Halfedge_ha
 }
 
 
-Handle<Value> Arrangement2Halfedge::ToPOD(const Arrangement_2::Halfedge_handle &halfedge, bool precise)
+Local<Value> Arrangement2Halfedge::ToPOD(
+    Isolate *isolate, const Arrangement_2::Halfedge_handle &halfedge, bool precise)
 {
-    HandleScope scope;
-    Local<Object> obj = Object::New();
-    return scope.Close(obj);
+    EscapableHandleScope scope(isolate);
+    Local<Object> obj = Object::New(isolate);
+    return scope.Escape(obj);
 }
 
 
-Handle<Value> Arrangement2Halfedge::ToString(const v8::Arguments &args)
+void Arrangement2Halfedge::ToString(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
-    Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
+    Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
     ostringstream str;
     str << "[object "  << Name << " " << edge.ptr() << " ";
     if (edge->is_fictitious()) {
         str << "FIC ";
     }
     str << "]";
-    return scope.Close(String::New(str.str().c_str()));
+    info.GetReturnValue().Set(String::NewFromUtf8(isolate, str.str().c_str()));
 }
 
 
-Handle<Value> Arrangement2Halfedge::IsFictitious(const v8::Arguments &args)
+void Arrangement2Halfedge::IsFictitious(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(edge->is_fictitious()));
+        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, edge->is_fictitious()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Halfedge::Source(const v8::Arguments &args)
+void Arrangement2Halfedge::Source(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
-        return scope.Close(Arrangement2Vertex::New(edge->source()));
+        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Arrangement2Vertex::New(isolate, edge->source()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Halfedge::Target(const v8::Arguments &args)
+void Arrangement2Halfedge::Target(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
-        return scope.Close(Arrangement2Vertex::New(edge->target()));
+        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Arrangement2Vertex::New(isolate, edge->target()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Halfedge::Face(const v8::Arguments &args)
+void Arrangement2Halfedge::Face(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
-        return scope.Close(Arrangement2Face::New(edge->face()));
+        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Arrangement2Face::New(isolate, edge->face()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Halfedge::Twin(const v8::Arguments &args)
+void Arrangement2Halfedge::Twin(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
-        return scope.Close(Arrangement2Halfedge::New(edge->twin()));
+        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Arrangement2Halfedge::New(isolate, edge->twin()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Halfedge::Prev(const v8::Arguments &args)
+void Arrangement2Halfedge::Prev(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
-        return scope.Close(Arrangement2Halfedge::New(edge->prev()));
+        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Arrangement2Halfedge::New(isolate, edge->prev()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Halfedge::Next(const v8::Arguments &args)
+void Arrangement2Halfedge::Next(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
-        return scope.Close(Arrangement2Halfedge::New(edge->next()));
+        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Arrangement2Halfedge::New(isolate, edge->next()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Halfedge::CCB(const v8::Arguments &args)
+void Arrangement2Halfedge::CCB(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
-        Local<Array> array = Array::New();
+        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
+        Local<Array> array = Array::New(isolate);
         Arrangement_2::Ccb_halfedge_circulator first, curr;
         first = curr = edge->ccb();
         uint32_t i = 0;
         do {
-            array->Set(i, Arrangement2Halfedge::New(curr));
+            array->Set(i, Arrangement2Halfedge::New(isolate, curr));
         } while(++i,++curr != first);
-        return scope.Close(array);
+        info.GetReturnValue().Set(array);
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Halfedge::Curve(const v8::Arguments &args)
+void Arrangement2Halfedge::Curve(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(args.This());
-        return scope.Close(Curve2::New(edge->curve()));
+        Arrangement_2::Halfedge_handle &edge = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Curve2::New(isolate, edge->curve()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }

--- a/src/Arrangement2Halfedge.h
+++ b/src/Arrangement2Halfedge.h
@@ -16,15 +16,17 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Arrangement_2::Halfedge_handle &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Arrangement_2::Halfedge_handle &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Arrangement_2::Halfedge_handle &halfedge, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(
+        v8::Isolate *isolate, const Arrangement_2::Halfedge_handle &halfedge, bool precise=true
+    );
 
 private:
 
@@ -33,16 +35,16 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> ToString(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsFictitious(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Source(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Target(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Face(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Twin(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Prev(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Next(const v8::Arguments &args);
-    static v8::Handle<v8::Value> CCB(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Curve(const v8::Arguments &args);
+    static void ToString(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsFictitious(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Source(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Target(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Face(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Twin(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Prev(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Next(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void CCB(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Curve(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/Arrangement2Vertex.cc
+++ b/src/Arrangement2Vertex.cc
@@ -13,23 +13,25 @@ using namespace std;
 const char *Arrangement2Vertex::Name = "Vertex";
 
 
-void Arrangement2Vertex::RegisterMethods()
+void Arrangement2Vertex::RegisterMethods(Isolate *isolate)
 {
-    SetPrototypeMethod(sConstructorTemplate, "toString", ToString);
-    SetPrototypeMethod(sConstructorTemplate, "isAtOpenBoundary", IsAtOpenBoundary);
-    SetPrototypeMethod(sConstructorTemplate, "isIsolated", IsIsolated);
-    SetPrototypeMethod(sConstructorTemplate, "degree", Degree);
-    SetPrototypeMethod(sConstructorTemplate, "incidentHalfedges", IncidentHalfedges);
-    SetPrototypeMethod(sConstructorTemplate, "face", Face);
-    SetPrototypeMethod(sConstructorTemplate, "point", Point);
-    SetPrototypeMethod(sConstructorTemplate, "parameterSpaceInX", ParameterSpaceInX);
-    SetPrototypeMethod(sConstructorTemplate, "parameterSpaceInY", ParameterSpaceInY);
+    HandleScope scope(isolate);
+    Local<FunctionTemplate> constructorTemplate = sConstructorTemplate.Get(isolate);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "toString", ToString);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isAtOpenBoundary", IsAtOpenBoundary);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isIsolated", IsIsolated);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "degree", Degree);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "incidentHalfedges", IncidentHalfedges);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "face", Face);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "point", Point);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "parameterSpaceInX", ParameterSpaceInX);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "parameterSpaceInY", ParameterSpaceInY);
 }
 
 
-bool Arrangement2Vertex::ParseArg(Local<Value> arg, Arrangement_2::Vertex_handle &receiver)
+bool Arrangement2Vertex::ParseArg(Isolate *isolate, Local<Value> arg, Arrangement_2::Vertex_handle &receiver)
 {
-    if (sConstructorTemplate->HasInstance(arg)) {
+    if (sConstructorTemplate.Get(isolate)->HasInstance(arg)) {
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
     }
@@ -38,18 +40,19 @@ bool Arrangement2Vertex::ParseArg(Local<Value> arg, Arrangement_2::Vertex_handle
 }
 
 
-Handle<Value> Arrangement2Vertex::ToPOD(const Arrangement_2::Vertex_handle &vertex, bool precise)
+Local<Value> Arrangement2Vertex::ToPOD(Isolate *isolate, const Arrangement_2::Vertex_handle &vertex, bool precise)
 {
-    HandleScope scope;
-    Local<Object> obj = Object::New();
-    return scope.Close(obj);
+    EscapableHandleScope scope(isolate);
+    Local<Object> obj = Object::New(isolate);
+    return scope.Escape(obj);
 }
 
 
-Handle<Value> Arrangement2Vertex::ToString(const v8::Arguments &args)
+void Arrangement2Vertex::ToString(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
-    Arrangement_2::Vertex_handle &vertex = ExtractWrapped(args.This());
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
+    Arrangement_2::Vertex_handle &vertex = ExtractWrapped(info.This());
     ostringstream str;
     str << "[object "  << Name << " " << vertex.ptr() <<" ";
     if (vertex->is_at_open_boundary()) {
@@ -80,116 +83,124 @@ Handle<Value> Arrangement2Vertex::ToString(const v8::Arguments &args)
         str << vertex->point();
     }
     str << "]";
-    return scope.Close(String::New(str.str().c_str()));
+    info.GetReturnValue().Set(String::NewFromUtf8(isolate, str.str().c_str()));
 }
 
 
-Handle<Value> Arrangement2Vertex::IsAtOpenBoundary(const v8::Arguments &args)
+void Arrangement2Vertex::IsAtOpenBoundary(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(vertex->is_at_open_boundary()));
+        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, vertex->is_at_open_boundary()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Vertex::IsIsolated(const v8::Arguments &args)
+void Arrangement2Vertex::IsIsolated(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(vertex->is_isolated()));
+        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, vertex->is_isolated()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Vertex::Degree(const v8::Arguments &args)
+void Arrangement2Vertex::Degree(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(args.This());
-        return scope.Close(Integer::New(vertex->degree()));
+        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Integer::New(isolate, vertex->degree()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Vertex::IncidentHalfedges(const v8::Arguments &args)
+void Arrangement2Vertex::IncidentHalfedges(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(args.This());
-        Local<Array> array = Array::New();
+        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(info.This());
+        Local<Array> array = Array::New(isolate);
         Arrangement_2::Halfedge_around_vertex_circulator first, curr;
         first = curr = vertex->incident_halfedges();
         uint32_t i = 0;
         do {
-            array->Set(i, Arrangement2Halfedge::New(curr));
+            array->Set(i, Arrangement2Halfedge::New(isolate, curr));
         } while(++i,++curr != first);
-        return scope.Close(array);
+        info.GetReturnValue().Set(array);
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Vertex::Face(const v8::Arguments &args)
+void Arrangement2Vertex::Face(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(args.This());
-        return scope.Close(Arrangement2Face::New(vertex->face()));
+        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Arrangement2Face::New(isolate, vertex->face()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Vertex::Point(const v8::Arguments &args)
+void Arrangement2Vertex::Point(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(args.This());
-        return scope.Close(Point2::New(vertex->point()));
+        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Point2::New(isolate, vertex->point()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Vertex::ParameterSpaceInX(const v8::Arguments &args)
+void Arrangement2Vertex::ParameterSpaceInX(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(args.This());
-        return scope.Close(Integer::New(vertex->parameter_space_in_x()));
+        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Integer::New(isolate, vertex->parameter_space_in_x()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Arrangement2Vertex::ParameterSpaceInY(const v8::Arguments &args)
+void Arrangement2Vertex::ParameterSpaceInY(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(args.This());
-        return scope.Close(Integer::New(vertex->parameter_space_in_y()));
+        Arrangement_2::Vertex_handle &vertex = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Integer::New(isolate, vertex->parameter_space_in_y()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }

--- a/src/Arrangement2Vertex.h
+++ b/src/Arrangement2Vertex.h
@@ -16,15 +16,17 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Arrangement_2::Vertex_handle &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Arrangement_2::Vertex_handle &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Arrangement_2::Vertex_handle &Vertex, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(
+        v8::Isolate *isolate, const Arrangement_2::Vertex_handle &Vertex, bool precise=true
+    );
 
 private:
 
@@ -33,15 +35,15 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> ToString(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsAtOpenBoundary(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsIsolated(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Degree(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IncidentHalfedges(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Face(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Point(const v8::Arguments &args);
-    static v8::Handle<v8::Value> ParameterSpaceInX(const v8::Arguments &args);
-    static v8::Handle<v8::Value> ParameterSpaceInY(const v8::Arguments &args);
+    static void ToString(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsAtOpenBoundary(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsIsolated(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Degree(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IncidentHalfedges(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Face(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Point(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void ParameterSpaceInX(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void ParameterSpaceInY(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/BBox2.h
+++ b/src/BBox2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Bbox_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Bbox_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Bbox_2 &box, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Bbox_2 &box, bool precise=true);
 
 private:
 
@@ -33,8 +33,8 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> Overlaps(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Add(const v8::Arguments &args);
+    static void Overlaps(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Add(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/CGALWrapper.h
+++ b/src/CGALWrapper.h
@@ -3,6 +3,7 @@
 
 #include "cgal_types.h"
 #include "node.h"
+#include "node_object_wrap.h"
 #include "v8.h"
 
 
@@ -15,31 +16,33 @@ public:
     virtual ~CGALWrapper();
 
     template<typename ParentScope>
-    static void Init(v8::Handle<ParentScope> exports);
+    static void Init(v8::Local<ParentScope> exports);
 
-    static v8::Handle<v8::Value> New(const CGALClass &CGALInstance);
+    static v8::Local<v8::Value> New(v8::Isolate *isolate, const CGALClass &CGALInstance);
 
     template<typename NumberPrimitive>
-    static bool ParseArg(v8::Local<v8::Value> arg, NumberPrimitive &parsed);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, NumberPrimitive &parsed);
 
     template<typename OutputIterator>
-    static bool ParseSeqArg(v8::Local<v8::Value> arg, OutputIterator iterator);
+    static bool ParseSeqArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, OutputIterator iterator);
 
     template<typename ForwardIterator>
-    static v8::Handle<v8::Value> SeqToPOD(ForwardIterator first, ForwardIterator last, bool precise);
+    static v8::Local<v8::Value> SeqToPOD(
+        v8::Isolate *isolate, ForwardIterator first, ForwardIterator last, bool precise
+    );
 
 protected:
 
     CGALClass mWrapped;
 
-    static v8::Persistent<v8::FunctionTemplate> sConstructorTemplate;
+    static v8::Global<v8::FunctionTemplate> sConstructorTemplate;
 
-    static CGALClass &ExtractWrapped(v8::Handle<v8::Object> obj);
+    static CGALClass &ExtractWrapped(v8::Local<v8::Object> obj);
 
-    static v8::Handle<v8::Value> New(const v8::Arguments &args);
-    static v8::Handle<v8::Value> ToPOD(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Inspect(const v8::Arguments &args);
-    static v8::Handle<v8::Value> ToString(const v8::Arguments &args);
+    static void New(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void ToPOD(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void Inspect(const v8::FunctionCallbackInfo<v8::Value> &args);
+    static void ToString(const v8::FunctionCallbackInfo<v8::Value> &args);
 
 };
 

--- a/src/Curve2.cc
+++ b/src/Curve2.cc
@@ -13,41 +13,45 @@ using namespace std;
 const char *Curve2::Name = "Curve2";
 
 
-void Curve2::RegisterMethods()
+void Curve2::RegisterMethods(Isolate *isolate)
 {
-    SetPrototypeMethod(sConstructorTemplate, "isSegment", IsSegment);
-    SetPrototypeMethod(sConstructorTemplate, "segment", Segment);
-    SetPrototypeMethod(sConstructorTemplate, "isRay", IsRay);
-    SetPrototypeMethod(sConstructorTemplate, "ray", Ray);
-    SetPrototypeMethod(sConstructorTemplate, "isLine", IsLine);
-    SetPrototypeMethod(sConstructorTemplate, "line", Line);
-    SetPrototypeMethod(sConstructorTemplate, "supportingLine", SupportingLine);
-    SetPrototypeMethod(sConstructorTemplate, "source", Source);
-    SetPrototypeMethod(sConstructorTemplate, "target", Target);
+    HandleScope scope(isolate);
+    Local<FunctionTemplate> constructorTemplate = sConstructorTemplate.Get(isolate);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isSegment", IsSegment);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "segment", Segment);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isRay", IsRay);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "ray", Ray);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isLine", IsLine);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "line", Line);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "supportingLine", SupportingLine);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "source", Source);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "target", Target);
 }
 
 
-bool Curve2::ParseArg(Local<Value> arg, Curve_2 &receiver)
+bool Curve2::ParseArg(Isolate *isolate, Local<Value> arg, Curve_2 &receiver)
 {
-    if (sConstructorTemplate->HasInstance(arg)) {
+    HandleScope scope(isolate);
+
+    if (sConstructorTemplate.Get(isolate)->HasInstance(arg)) {
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
     }
 
     Segment_2 segment;
-    if (Segment2::ParseArg(arg, segment)) {
+    if (Segment2::ParseArg(isolate, arg, segment)) {
         receiver = Curve_2(segment);
         return true;
     }
 
     Line_2 line;
-    if (Line2::ParseArg(arg, line)) {
+    if (Line2::ParseArg(isolate, arg, line)) {
         receiver = Curve_2(line);
         return true;
     }
 
     Ray_2 ray;
-    if (Ray2::ParseArg(arg, ray)) {
+    if (Ray2::ParseArg(isolate, arg, ray)) {
         receiver = Curve_2(ray);
         return true;
     }
@@ -56,126 +60,135 @@ bool Curve2::ParseArg(Local<Value> arg, Curve_2 &receiver)
 }
 
 
-Handle<Value> Curve2::ToPOD(const Curve_2 &curve, bool precise)
+Local<Value> Curve2::ToPOD(Isolate *isolate, const Curve_2 &curve, bool precise)
 {
-    HandleScope scope;
-    Local<Object> obj = Object::New();
-    return scope.Close(obj);
+    EscapableHandleScope scope(isolate);
+    Local<Object> obj = Object::New(isolate);
+    return scope.Escape(obj);
 }
 
 
-Handle<Value> Curve2::IsSegment(const v8::Arguments &args)
+void Curve2::IsSegment(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Curve_2 &curve = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(curve.is_segment()));
+        Curve_2 &curve = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, curve.is_segment()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
-    }
-}
-
-
-Handle<Value> Curve2::Segment(const v8::Arguments &args)
-{
-    HandleScope scope;
-    try {
-        Curve_2 &curve = ExtractWrapped(args.This());
-        return scope.Close(Segment2::New(curve.segment()));
-    }
-    catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Curve2::IsRay(const v8::Arguments &args)
+void Curve2::Segment(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Curve_2 &curve = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(curve.is_ray()));
+        Curve_2 &curve = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Segment2::New(isolate, curve.segment()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Curve2::Ray(const v8::Arguments &args)
+void Curve2::IsRay(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Curve_2 &curve = ExtractWrapped(args.This());
-        return scope.Close(Ray2::New(curve.ray()));
+        Curve_2 &curve = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, curve.is_ray()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Curve2::IsLine(const v8::Arguments &args)
+void Curve2::Ray(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Curve_2 &curve = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(curve.is_line()));
+        Curve_2 &curve = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Ray2::New(isolate, curve.ray()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Curve2::Line(const v8::Arguments &args)
+void Curve2::IsLine(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Curve_2 &curve = ExtractWrapped(args.This());
-        return scope.Close(Line2::New(curve.line()));
+        Curve_2 &curve = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, curve.is_line()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Curve2::SupportingLine(const v8::Arguments &args)
+void Curve2::Line(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Curve_2 &curve = ExtractWrapped(args.This());
-        return scope.Close(Line2::New(curve.supporting_line()));
+        Curve_2 &curve = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Line2::New(isolate, curve.line()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Curve2::Source(const v8::Arguments &args)
+void Curve2::SupportingLine(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Curve_2 &curve = ExtractWrapped(args.This());
-        return scope.Close(Point2::New(curve.source()));
+        Curve_2 &curve = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Line2::New(isolate, curve.supporting_line()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Curve2::Target(const v8::Arguments &args)
+void Curve2::Source(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Curve_2 &curve = ExtractWrapped(args.This());
-        return scope.Close(Point2::New(curve.target()));
+        Curve_2 &curve = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Point2::New(isolate, curve.source()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
+    }
+}
+
+
+void Curve2::Target(const FunctionCallbackInfo<Value> &info)
+{
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
+    try {
+        Curve_2 &curve = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Point2::New(isolate, curve.target()));
+    }
+    catch (const exception &e) {
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }

--- a/src/Curve2.h
+++ b/src/Curve2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Curve_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Curve_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Curve_2 &curve, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Curve_2 &curve, bool precise=true);
 
 private:
 
@@ -33,15 +33,15 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> IsSegment(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Segment(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsRay(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Ray(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsLine(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Line(const v8::Arguments &args);
-    static v8::Handle<v8::Value> SupportingLine(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Source(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Target(const v8::Arguments &args);
+    static void IsSegment(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Segment(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsRay(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Ray(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsLine(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Line(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void SupportingLine(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Source(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Target(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/D2.cc
+++ b/src/D2.cc
@@ -13,71 +13,79 @@ using namespace v8;
 using namespace std;
 
 
-void D2::Init(v8::Handle<v8::Object> exports)
+void D2::Init(v8::Local<v8::Object> exports)
 {
-    exports->Set(String::NewSymbol("doIntersect"), FunctionTemplate::New(DoIntersect)->GetFunction());
-    exports->Set(String::NewSymbol("convexPartition2"), FunctionTemplate::New(ConvexPartition2)->GetFunction());
-    exports->Set(String::NewSymbol("convexHull2"), FunctionTemplate::New(ConvexHull2)->GetFunction());
-    exports->Set(String::NewSymbol("collinear"), FunctionTemplate::New(Collinear)->GetFunction());
+    NODE_SET_METHOD(exports, "doIntersect", DoIntersect);
+    NODE_SET_METHOD(exports, "convexPartition2", ConvexPartition2);
+    NODE_SET_METHOD(exports, "convexHull2", ConvexHull2);
+    NODE_SET_METHOD(exports, "collinear", Collinear);
 }
 
-Handle<Value> DoIntersect(const Arguments &args)
+
+void DoIntersect(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
 
     try {
 
-        ARGS_ASSERT(args.Length() == 2);
+        ARGS_ASSERT(isolate, info.Length() == 2);
 
         Polygon_2 poly0;
-        if (Polygon2::ParseArg(args[0], poly0)) {
+        if (Polygon2::ParseArg(isolate, info[0], poly0)) {
 
             Polygon_2 poly1;
-            if (Polygon2::ParseArg(args[1], poly1)) {
-                return scope.Close(Boolean::New(CGAL::do_intersect(poly0, poly1)));
+            if (Polygon2::ParseArg(isolate, info[1], poly1)) {
+                info.GetReturnValue().Set(Boolean::New(isolate, CGAL::do_intersect(poly0, poly1)));
+                return;
             }
 
             Polygon_with_holes_2 pwh1;
-            if (PolygonWithHoles2::ParseArg(args[1], pwh1)) {
-                return scope.Close(Boolean::New(CGAL::do_intersect(poly0, pwh1)));
+            if (PolygonWithHoles2::ParseArg(isolate, info[1], pwh1)) {
+                info.GetReturnValue().Set(Boolean::New(isolate, CGAL::do_intersect(poly0, pwh1)));
+                return;
             }
 
-            ARGS_ASSERT(false);
+            ARGS_ASSERT(isolate, false);
         }
 
         Polygon_with_holes_2 pwh0;
-        if (PolygonWithHoles2::ParseArg(args[0], pwh0)) {
+        if (PolygonWithHoles2::ParseArg(isolate, info[0], pwh0)) {
 
             Polygon_2 poly1;
-            if (Polygon2::ParseArg(args[1], poly1)) {
-                return scope.Close(Boolean::New(CGAL::do_intersect(pwh0, poly1)));
+            if (Polygon2::ParseArg(isolate, info[1], poly1)) {
+                info.GetReturnValue().Set(Boolean::New(isolate, CGAL::do_intersect(pwh0, poly1)));
+                return;
             }
 
             Polygon_with_holes_2 pwh1;
-            if (PolygonWithHoles2::ParseArg(args[1], pwh1)) {
-                return scope.Close(Boolean::New(CGAL::do_intersect(pwh0, pwh1)));
+            if (PolygonWithHoles2::ParseArg(isolate, info[1], pwh1)) {
+                info.GetReturnValue().Set(Boolean::New(isolate, CGAL::do_intersect(pwh0, pwh1)));
+                return;
             }
 
-            ARGS_ASSERT(false);
+            ARGS_ASSERT(isolate, false);
         }
 
-        ARGS_ASSERT(false);
+        ARGS_ASSERT(isolate, false);
     }
 
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 
 }
 
-Handle<Value> ConvexPartition2(const Arguments& args)
+
+void ConvexPartition2(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
 
     try {
 
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Polygon2::ParseArg, Polygon_2, inputPoly, args[0]);
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Polygon2::ParseArg, Polygon_2, inputPoly, info[0]);
         Partition_Traits partition_traits;
         list<Partition_Traits::Polygon_2> partition;
         CGAL::approx_convex_partition_2(
@@ -86,68 +94,70 @@ Handle<Value> ConvexPartition2(const Arguments& args)
             partition_traits
         );
 
-        Local<Array> array = Array::New();
+        Local<Array> array = Array::New(isolate);
         uint32_t i;
         list<Partition_Traits::Polygon_2>::iterator it;
         for(it=partition.begin(),i=0; it!=partition.end(); ++it,++i) {
-            array->Set(i, Polygon2::New(Polygon_2(it->vertices_begin(), it->vertices_end())));
+            array->Set(i, Polygon2::New(isolate, Polygon_2(it->vertices_begin(), it->vertices_end())));
         }
 
-        return scope.Close(array);
+        info.GetReturnValue().Set(array);
     }
 
     catch(const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 
 }
 
 
-Handle<Value> ConvexHull2(const Arguments& args)
+void ConvexHull2(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
 
     try {
 
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL_SEQ(Point2::ParseSeqArg, list<Point_2>, points, args[0]);
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL_SEQ(isolate, Point2::ParseSeqArg, list<Point_2>, points, info[0]);
         list<Point_2> hull;
         CGAL::convex_hull_2(points.begin(), points.end(), back_inserter(hull));
 
-        Local<Array> array = Array::New();
+        Local<Array> array = Array::New(isolate);
         uint32_t i;
         list<Point_2>::iterator it;
         for(it=hull.begin(),i=0; it!=hull.end(); ++it,++i) {
-            array->Set(i, Point2::New(*it));
+            array->Set(i, Point2::New(isolate, *it));
         }
 
-        return scope.Close(array);
+        info.GetReturnValue().Set(array);
     }
 
     catch(const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 
 }
 
 
-Handle<Value> Collinear(const Arguments &args)
+void Collinear(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
 
     try {
 
-        ARGS_ASSERT(args.Length() == 3);
-        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, p0, args[0])
-        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, p1, args[1])
-        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, p2, args[2])
+        ARGS_ASSERT(isolate, info.Length() == 3);
+        ARGS_PARSE_LOCAL(isolate, Point2::ParseArg, Point_2, p0, info[0])
+        ARGS_PARSE_LOCAL(isolate, Point2::ParseArg, Point_2, p1, info[1])
+        ARGS_PARSE_LOCAL(isolate, Point2::ParseArg, Point_2, p2, info[2])
 
-        return scope.Close(Boolean::New(CGAL::collinear(p0, p1, p2)));
+        info.GetReturnValue().Set(Boolean::New(isolate, CGAL::collinear(p0, p1, p2)));
 
     }
 
     catch(const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 
 }

--- a/src/D2.h
+++ b/src/D2.h
@@ -10,21 +10,21 @@ namespace D2
 {
     // Add function templates for CGAL global 2d functions to the package exports.  Called at module
     // load time via the module init function.
-    void Init(v8::Handle<v8::Object> exports);
+    void Init(v8::Local<v8::Object> exports);
 }
 
 // Takes a Polygon2 constructable and returns an array of Polygon2 objects that are an approximately
 // optimal (within 4x) partition of the origin polygon into convex sub-polygons.
-v8::Handle<v8::Value> ConvexPartition2(const v8::Arguments &args);
+void ConvexPartition2(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 // Takes an array of Point2 constructables and returns the convex hull of those points as an array
 // of Point2 objects.
-v8::Handle<v8::Value> ConvexHull2(const v8::Arguments &args);
+void ConvexHull2(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 // Takes two Polygon2 or PolygonWithHoles2 constructables (or a mix) and returns true if they
 // intersect.
-v8::Handle<v8::Value> DoIntersect(const v8::Arguments &args);
+void DoIntersect(const v8::FunctionCallbackInfo<v8::Value> &info);
 
-v8::Handle<v8::Value> Collinear(const v8::Arguments &args);
+void Collinear(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 #endif // !defined(D2_H)

--- a/src/Direction2.cc
+++ b/src/Direction2.cc
@@ -14,46 +14,50 @@ using namespace std;
 const char *Direction2::Name = "Direction2";
 
 
-void Direction2::RegisterMethods()
+void Direction2::RegisterMethods(Isolate *isolate)
 {
-    SetPrototypeMethod(sConstructorTemplate, "isEqual", IsEqual);
-    SetPrototypeMethod(sConstructorTemplate, "isLessThan", IsLessThan);
-    SetPrototypeMethod(sConstructorTemplate, "isGreaterThan", IsGreaterThan);
-    SetPrototypeMethod(sConstructorTemplate, "isCCWBetween", IsCCWBetween);
-    SetPrototypeMethod(sConstructorTemplate, "opposite", Opposite);
-    SetPrototypeMethod(sConstructorTemplate, "toVector", ToVector);
-    SetPrototypeMethod(sConstructorTemplate, "dx", DX);
-    SetPrototypeMethod(sConstructorTemplate, "dy", DY);
+    HandleScope scope(isolate);
+    Local<FunctionTemplate> constructorTemplate = sConstructorTemplate.Get(isolate);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isEqual", IsEqual);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isLessThan", IsLessThan);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isGreaterThan", IsGreaterThan);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isCCWBetween", IsCCWBetween);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "opposite", Opposite);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "toVector", ToVector);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "dx", DX);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "dy", DY);
 }
 
 
-bool Direction2::ParseArg(Local<Value> arg, Direction_2 &receiver)
+bool Direction2::ParseArg(Isolate *isolate, Local<Value> arg, Direction_2 &receiver)
 {
-    if (sConstructorTemplate->HasInstance(arg)) {
+    HandleScope scope(isolate);
+
+    if (sConstructorTemplate.Get(isolate)->HasInstance(arg)) {
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
     }
 
     Vector_2 vector;
-    if (Vector2::ParseArg(arg, vector)) {
+    if (Vector2::ParseArg(isolate, arg, vector)) {
         receiver = Direction_2(vector);
         return true;
     }
 
     Line_2 line;
-    if (Line2::ParseArg(arg, line)) {
+    if (Line2::ParseArg(isolate, arg, line)) {
         receiver = Direction_2(line);
         return true;
     }
 
     Ray_2 ray;
-    if (Ray2::ParseArg(arg, ray)) {
+    if (Ray2::ParseArg(isolate, arg, ray)) {
         receiver = Direction_2(ray);
         return true;
     }
 
     Segment_2 segment;
-    if (Segment2::ParseArg(arg, segment)) {
+    if (Segment2::ParseArg(isolate, arg, segment)) {
         receiver = Direction_2(segment);
         return true;
     }
@@ -62,8 +66,8 @@ bool Direction2::ParseArg(Local<Value> arg, Direction_2 &receiver)
         Local<Object> inits = Local<Object>::Cast(arg);
 
         K::FT dx, dy;
-        if (::ParseArg(inits->Get(String::NewSymbol("dx")), dx) &&
-            ::ParseArg(inits->Get(String::NewSymbol("dy")), dy))
+        if (::ParseArg(isolate, inits->Get(SYMBOL(isolate, "dx")), dx) &&
+            ::ParseArg(isolate, inits->Get(SYMBOL(isolate, "dy")), dy))
         {
             receiver = Direction_2(dx, dy);
             return true;
@@ -75,10 +79,10 @@ bool Direction2::ParseArg(Local<Value> arg, Direction_2 &receiver)
 }
 
 
-Handle<Value> Direction2::ToPOD(const Direction_2 &direction, bool precise)
+Local<Value> Direction2::ToPOD(Isolate *isolate, const Direction_2 &direction, bool precise)
 {
-    HandleScope scope;
-    Local<Object> obj = Object::New();
+    EscapableHandleScope scope(isolate);
+    Local<Object> obj = Object::New(isolate);
 
     if (precise) {
 
@@ -88,7 +92,7 @@ Handle<Value> Direction2::ToPOD(const Direction_2 &direction, bool precise)
 #else
         dxstr << setprecision(20) << direction.dx();
 #endif
-        obj->Set(String::NewSymbol("dx"), String::New(dxstr.str().c_str()));
+        obj->Set(SYMBOL(isolate, "dx"), String::NewFromUtf8(isolate, dxstr.str().c_str()));
 
         ostringstream dystr;
 #if CGAL_USE_EPECK
@@ -96,125 +100,135 @@ Handle<Value> Direction2::ToPOD(const Direction_2 &direction, bool precise)
 #else
         dystr << setprecision(20) << direction.dy();
 #endif
-        obj->Set(String::NewSymbol("dy"), String::New(dystr.str().c_str()));
+        obj->Set(SYMBOL(isolate, "dy"), String::NewFromUtf8(isolate, dystr.str().c_str()));
 
     } else {
-        obj->Set(String::NewSymbol("dx"), Number::New(CGAL::to_double(direction.dx())));
-        obj->Set(String::NewSymbol("dy"), Number::New(CGAL::to_double(direction.dy())));
+
+        obj->Set(SYMBOL(isolate, "dx"), Number::New(isolate, CGAL::to_double(direction.dx())));
+        obj->Set(SYMBOL(isolate, "dy"), Number::New(isolate, CGAL::to_double(direction.dy())));
+
     }
 
-    return scope.Close(obj);
+    return scope.Escape(obj);
 }
 
 
-Handle<Value> Direction2::IsEqual(const v8::Arguments &args)
+void Direction2::IsEqual(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Direction_2 &thisDir = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Direction2::ParseArg, Direction_2, otherDir, args[0]);
-        return scope.Close(Boolean::New(thisDir == otherDir));
+        Direction_2 &thisDir = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Direction2::ParseArg, Direction_2, otherDir, info[0]);
+        info.GetReturnValue().Set(Boolean::New(isolate, thisDir == otherDir));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
-    }
-}
-
-
-Handle<Value> Direction2::IsLessThan(const v8::Arguments &args)
-{
-    HandleScope scope;
-    try {
-        Direction_2 &thisDir = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Direction2::ParseArg, Direction_2, otherDir, args[0]);
-        return scope.Close(Boolean::New(thisDir < otherDir));
-    }
-    catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Direction2::IsGreaterThan(const v8::Arguments &args)
+void Direction2::IsLessThan(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Direction_2 &thisDir = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Direction2::ParseArg, Direction_2, otherDir, args[0]);
-        return scope.Close(Boolean::New(thisDir > otherDir));
+        Direction_2 &thisDir = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Direction2::ParseArg, Direction_2, otherDir, info[0]);
+        info.GetReturnValue().Set(Boolean::New(isolate, thisDir < otherDir));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Direction2::IsCCWBetween(const v8::Arguments &args)
+void Direction2::IsGreaterThan(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Direction_2 &dir = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 2);
-        ARGS_PARSE_LOCAL(Direction2::ParseArg, Direction_2, d1, args[0]);
-        ARGS_PARSE_LOCAL(Direction2::ParseArg, Direction_2, d2, args[1]);
-        return scope.Close(Boolean::New(dir.counterclockwise_in_between(d1, d2)));
+        Direction_2 &thisDir = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Direction2::ParseArg, Direction_2, otherDir, info[0]);
+        info.GetReturnValue().Set(Boolean::New(isolate, thisDir > otherDir));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Direction2::Opposite(const v8::Arguments &args)
+void Direction2::IsCCWBetween(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Direction_2 &dir = ExtractWrapped(args.This());
-        return scope.Close(Direction2::New(-dir));
+        Direction_2 &dir = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 2);
+        ARGS_PARSE_LOCAL(isolate, Direction2::ParseArg, Direction_2, d1, info[0]);
+        ARGS_PARSE_LOCAL(isolate, Direction2::ParseArg, Direction_2, d2, info[1]);
+        info.GetReturnValue().Set(Boolean::New(isolate, dir.counterclockwise_in_between(d1, d2)));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Direction2::ToVector(const v8::Arguments &args)
+void Direction2::Opposite(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Direction_2 &dir = ExtractWrapped(args.This());
-        return scope.Close(Vector2::New(dir.vector()));
+        Direction_2 &dir = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Direction2::New(isolate, -dir));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Direction2::DX(const v8::Arguments &args)
+void Direction2::ToVector(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Direction_2 &dir = ExtractWrapped(args.This());
-        return scope.Close(Number::New(CGAL::to_double(dir.dx())));
+        Direction_2 &dir = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Vector2::New(isolate, dir.vector()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Direction2::DY(const v8::Arguments &args)
+void Direction2::DX(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Direction_2 &dir = ExtractWrapped(args.This());
-        return scope.Close(Number::New(CGAL::to_double(dir.dy())));
+        Direction_2 &dir = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, CGAL::to_double(dir.dx())));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
+    }
+}
+
+
+void Direction2::DY(const FunctionCallbackInfo<Value> &info)
+{
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
+    try {
+        Direction_2 &dir = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, CGAL::to_double(dir.dy())));
+    }
+    catch (const exception &e) {
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }

--- a/src/Direction2.h
+++ b/src/Direction2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Direction_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Direction_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Direction_2 &direction, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Direction_2 &direction, bool precise=true);
 
 private:
 
@@ -33,14 +33,14 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsLessThan(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsGreaterThan(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsCCWBetween(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Opposite(const v8::Arguments &args);
-    static v8::Handle<v8::Value> ToVector(const v8::Arguments &args);
-    static v8::Handle<v8::Value> DX(const v8::Arguments &args);
-    static v8::Handle<v8::Value> DY(const v8::Arguments &args);
+    static void IsEqual(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsLessThan(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsGreaterThan(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsCCWBetween(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Opposite(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void ToVector(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void DX(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void DY(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/Line2.h
+++ b/src/Line2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Line_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Line_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Line_2 &Line, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Line_2 &Line, bool precise=true);
 
 private:
 
@@ -33,11 +33,11 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsDegenerate(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsHorizontal(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsVertical(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Opposite(const v8::Arguments &args);
+    static void IsEqual(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsDegenerate(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsHorizontal(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsVertical(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Opposite(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/NefPolyhedron2.cc
+++ b/src/NefPolyhedron2.cc
@@ -19,18 +19,20 @@ namespace {
 const char *NefPolyhedron2::Name = "NefPolyhedron2";
 
 
-void NefPolyhedron2::RegisterMethods()
+void NefPolyhedron2::RegisterMethods(Isolate *isolate)
 {
-    NODE_DEFINE_CONSTANT(sConstructorTemplate, EXCLUDED);
-    NODE_DEFINE_CONSTANT(sConstructorTemplate, INCLUDED);
-    NODE_DEFINE_CONSTANT(sConstructorTemplate, EMPTY);
-    NODE_DEFINE_CONSTANT(sConstructorTemplate, COMPLETE);
+    // HandleScope scope(isolate);
+    // Local<FunctionTemplate> constructorTemplate = sConstructorTemplate.Get(isolate);
+    // NODE_DEFINE_CONSTANT(constructorTemplate, EXCLUDED);
+    // NODE_DEFINE_CONSTANT(constructorTemplate, INCLUDED);
+    // NODE_DEFINE_CONSTANT(constructorTemplate, EMPTY);
+    // NODE_DEFINE_CONSTANT(constructorTemplate, COMPLETE);
 }
 
 
-bool NefPolyhedron2::ParseArg(Local<Value> arg, Nef_polyhedron_2 &receiver)
+bool NefPolyhedron2::ParseArg(v8::Isolate *isolate, Local<Value> arg, Nef_polyhedron_2 &receiver)
 {
-    if (sConstructorTemplate->HasInstance(arg)) {
+    if (sConstructorTemplate.Get(isolate)->HasInstance(arg)) {
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
     }
@@ -39,9 +41,9 @@ bool NefPolyhedron2::ParseArg(Local<Value> arg, Nef_polyhedron_2 &receiver)
 }
 
 
-Handle<Value> NefPolyhedron2::ToPOD(const Nef_polyhedron_2 &nef, bool precise)
+Local<Value> NefPolyhedron2::ToPOD(v8::Isolate *isolate, const Nef_polyhedron_2 &nef, bool precise)
 {
-    HandleScope scope;
-    Local<Object> obj = Object::New();
-    return scope.Close(obj);
+    EscapableHandleScope scope(isolate);
+    Local<Object> obj = Object::New(isolate);
+    return scope.Escape(obj);
 }

--- a/src/NefPolyhedron2.h
+++ b/src/NefPolyhedron2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Nef_polyhedron_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Nef_polyhedron_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Nef_polyhedron_2 &nef, bool precise=false);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Nef_polyhedron_2 &nef, bool precise=false);
 
 private:
 

--- a/src/Point2.h
+++ b/src/Point2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Point_2 &receiver);
+    static bool ParseArg(v8::Isolate *Isolate, v8::Local<v8::Value> arg, Point_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Point_2 &point, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Point_2 &point, bool precise=true);
 
 private:
 
@@ -33,10 +33,10 @@ private:
     //      the semantics and names of CGAL::Point_2 methods.
     //
 
-    static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);
-    static v8::Handle<v8::Value> X(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Y(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Transform(const v8::Arguments &args);
+    static void IsEqual(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void X(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Y(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Transform(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/Polygon2.cc
+++ b/src/Polygon2.cc
@@ -11,179 +11,192 @@ using namespace std;
 const char *Polygon2::Name = "Polygon2";
 
 
-void Polygon2::RegisterMethods()
+void Polygon2::RegisterMethods(Isolate *isolate)
 {
-    SetPrototypeMethod(sConstructorTemplate, "isEqual", IsEqual);
-    SetPrototypeMethod(sConstructorTemplate, "isSimple", IsSimple);
-    SetPrototypeMethod(sConstructorTemplate, "isConvex", IsConvex);
-    SetPrototypeMethod(sConstructorTemplate, "orientation", Orientation);
-    SetPrototypeMethod(sConstructorTemplate, "orientedSide", OrientedSide);
-    SetPrototypeMethod(sConstructorTemplate, "boundedSide", BoundedSide);
-    SetPrototypeMethod(sConstructorTemplate, "area", Area);
-    SetPrototypeMethod(sConstructorTemplate, "coords", Coords);
+    HandleScope scope(isolate);
+    Local<FunctionTemplate> constructorTemplate = sConstructorTemplate.Get(isolate);
 
-    SetMethod(sConstructorTemplate, "transform", Transform);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isEqual", IsEqual);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isSimple", IsSimple);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isConvex", IsConvex);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "orientation", Orientation);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "orientedSide", OrientedSide);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "boundedSide", BoundedSide);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "area", Area);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "coords", Coords);
+
+    NODE_SET_METHOD(constructorTemplate, "transform", Transform);
 }
 
 
-bool Polygon2::ParseArg(v8::Local<v8::Value> arg, Polygon_2 &receiver)
+bool Polygon2::ParseArg(Isolate *isolate, Local<Value> arg, Polygon_2 &receiver)
 {
-    if (sConstructorTemplate->HasInstance(arg)) {
+    if (sConstructorTemplate.Get(isolate)->HasInstance(arg)) {
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
     }
 
     if (arg->IsArray()) {
-        return Point2::ParseSeqArg(arg, back_inserter(receiver));
+        return Point2::ParseSeqArg(isolate, arg, back_inserter(receiver));
     }
 
     return false;
 }
 
 
-Handle<Value> Polygon2::ToPOD(const Polygon_2 &poly, bool precise)
+Local<Value> Polygon2::ToPOD(Isolate *isolate, const Polygon_2 &poly, bool precise)
 {
-    HandleScope scope;
-    return scope.Close(Point2::SeqToPOD(poly.vertices_begin(), poly.vertices_end(), precise));
+    EscapableHandleScope scope(isolate);
+    return scope.Escape(Point2::SeqToPOD(isolate, poly.vertices_begin(), poly.vertices_end(), precise));
 }
 
 
-Handle<Value> Polygon2::IsEqual(const Arguments &args)
+void Polygon2::IsEqual(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Polygon_2 &thisPoly = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Polygon2::ParseArg, Polygon_2, otherPoly, args[0]);
-        return scope.Close(Boolean::New(thisPoly == otherPoly));
+        Polygon_2 &thisPoly = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Polygon2::ParseArg, Polygon_2, otherPoly, info[0]);
+        info.GetReturnValue().Set(Boolean::New(isolate, thisPoly == otherPoly));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Polygon2::IsSimple(const Arguments &args)
+void Polygon2::IsSimple(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Polygon_2 &poly = ExtractWrapped(args.This());
+        Polygon_2 &poly = ExtractWrapped(info.This());
         // NOTE(ocderby): CGAL Segfaults on linux if the polygon has no points in it,
         // so catch that here.
         if (poly.size() == 0) {
-            return scope.Close(Boolean::New(false));
+            info.GetReturnValue().Set(Boolean::New(isolate, false));
+            return;
         }
-        return scope.Close(Boolean::New(poly.is_simple()));
+        info.GetReturnValue().Set(Boolean::New(isolate, poly.is_simple()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Polygon2::IsConvex(const Arguments &args)
+void Polygon2::IsConvex(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Polygon_2 &poly = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(poly.is_convex()));
+        Polygon_2 &poly = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, poly.is_convex()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Polygon2::Orientation(const Arguments &args)
+void Polygon2::Orientation(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Polygon_2 &poly = ExtractWrapped(args.This());
-        return scope.Close(Integer::New(poly.orientation()));
+        Polygon_2 &poly = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Integer::New(isolate, poly.orientation()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Polygon2::OrientedSide(const Arguments &args)
+void Polygon2::OrientedSide(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Polygon_2 &poly = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, point, args[0]);
-        return scope.Close(Integer::New(poly.oriented_side(point)));
+        Polygon_2 &poly = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Point2::ParseArg, Point_2, point, info[0]);
+        info.GetReturnValue().Set(Integer::New(isolate, poly.oriented_side(point)));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Polygon2::BoundedSide(const Arguments &args)
+void Polygon2::BoundedSide(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Polygon_2 &poly = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, point, args[0]);
-        return scope.Close(Integer::New(poly.bounded_side(point)));
+        Polygon_2 &poly = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Point2::ParseArg, Point_2, point, info[0]);
+        info.GetReturnValue().Set(Integer::New(isolate, poly.bounded_side(point)));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Polygon2::Area(const Arguments &args)
+void Polygon2::Area(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Polygon_2 &poly = ExtractWrapped(args.This());
-        return scope.Close(Number::New(CGAL::to_double(poly.area())));
+        Polygon_2 &poly = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Number::New(isolate, CGAL::to_double(poly.area())));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Polygon2::Transform(const Arguments &args)
+void Polygon2::Transform(const FunctionCallbackInfo<Value> &info)
 {
-  HandleScope scope;
+  Isolate *isolate = info.GetIsolate();
+  HandleScope scope(isolate);
   try {
-    ARGS_ASSERT(args.Length() == 2);
+    ARGS_ASSERT(isolate, info.Length() == 2);
 
     Aff_transformation_2 afft;
-    if (!AffTransformation2::ParseArg(args[0], afft)) {
-      ARGS_ASSERT(false);
+    if (!AffTransformation2::ParseArg(isolate, info[0], afft)) {
+      ARGS_ASSERT(isolate, false);
     }
 
     Polygon_2 poly;
-    if (!ParseArg(args[1], poly)) {
-      ARGS_ASSERT(false);
+    if (!ParseArg(isolate, info[1], poly)) {
+      ARGS_ASSERT(isolate, false);
     }
 
     Polygon_2 xpoly = CGAL::transform(afft, poly);
-    return scope.Close(New(xpoly));
+    info.GetReturnValue().Set(New(isolate, xpoly));
   }
   catch (const exception &e) {
-    return ThrowException(String::New(e.what()));
+    isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
   }
 }
 
 
-Handle<Value> Polygon2::Coords(const Arguments &args)
+void Polygon2::Coords(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
-    Polygon_2 &poly = ExtractWrapped(args.This());
-    Local<Array> array = Array::New();
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
+    Polygon_2 &poly = ExtractWrapped(info.This());
+    Local<Array> array = Array::New(isolate);
     Vertex_iterator it;
     uint32_t i;
     for(it=poly.vertices_begin(),i=0; it!=poly.vertices_end(); ++it,++i) {
-        array->Set(i, Point2::New(*it));
+        array->Set(i, Point2::New(isolate, *it));
     }
-    return scope.Close(array);
+    info.GetReturnValue().Set(array);
 }

--- a/src/Polygon2.h
+++ b/src/Polygon2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Polygon_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Polygon_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Polygon_2 &poly, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Polygon_2 &poly, bool precise=true);
 
 private:
 
@@ -33,15 +33,15 @@ private:
     //      the semantics and names of CGAL::Point_2 methods.
     //
 
-    static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsSimple(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsConvex(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Orientation(const v8::Arguments &args);
-    static v8::Handle<v8::Value> OrientedSide(const v8::Arguments &args);
-    static v8::Handle<v8::Value> BoundedSide(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Area(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Transform(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Coords(const v8::Arguments &args);
+    static void IsEqual(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsSimple(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsConvex(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Orientation(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void OrientedSide(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void BoundedSide(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Area(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Transform(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Coords(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/PolygonSet2.h
+++ b/src/PolygonSet2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Polygon_set_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Polygon_set_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Polygon_set_2 &polySet, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Polygon_set_2 &polySet, bool precise=true);
 
 private:
 
@@ -33,22 +33,22 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> PolygonsWithHoles(const v8::Arguments &args);
-    static v8::Handle<v8::Value> NumPolygonsWithHoles(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsEmpty(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsPlane(const v8::Arguments &args);
-    // static v8::Handle<v8::Value> Arrangement(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Clear(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Insert(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Complement(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Intersection(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Join(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Difference(const v8::Arguments &args);
-    static v8::Handle<v8::Value> SymmetricDifference(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Intersects(const v8::Arguments &args);
-    // static v8::Handle<v8::Value> Locate(const v8::Arguments &args);
-    static v8::Handle<v8::Value> OrientedSide(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsValid(const v8::Arguments &args);
+    static void PolygonsWithHoles(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void NumPolygonsWithHoles(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsEmpty(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsPlane(const v8::FunctionCallbackInfo<v8::Value> &info);
+    // static void Arrangement(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Clear(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Insert(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Complement(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Intersection(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Join(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Difference(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void SymmetricDifference(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Intersects(const v8::FunctionCallbackInfo<v8::Value> &info);
+    // static void Locate(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void OrientedSide(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsValid(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/PolygonWithHoles2.h
+++ b/src/PolygonWithHoles2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Polygon_with_holes_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Polygon_with_holes_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Polygon_with_holes_2 &poly, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Polygon_with_holes_2 &poly, bool precise=true);
 
 private:
 
@@ -33,10 +33,10 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Outer(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Holes(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsUnbounded(const v8::Arguments &args);
+    static void IsEqual(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Outer(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Holes(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsUnbounded(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/Ray2.cc
+++ b/src/Ray2.cc
@@ -13,26 +13,30 @@ using namespace std;
 const char *Ray2::Name = "Ray2";
 
 
-void Ray2::RegisterMethods()
+void Ray2::RegisterMethods(Isolate *isolate)
 {
-    SetPrototypeMethod(sConstructorTemplate, "isEqual", IsEqual);
-    SetPrototypeMethod(sConstructorTemplate, "source", Source);
-    SetPrototypeMethod(sConstructorTemplate, "point", Point);
-    SetPrototypeMethod(sConstructorTemplate, "direction", Direction);
-    SetPrototypeMethod(sConstructorTemplate, "toVector", ToVector);
-    SetPrototypeMethod(sConstructorTemplate, "supportingLine", SupportingLine);
-    SetPrototypeMethod(sConstructorTemplate, "opposite", Opposite);
-    SetPrototypeMethod(sConstructorTemplate, "isDegenerate", IsDegenerate);
-    SetPrototypeMethod(sConstructorTemplate, "isHorizontal", IsHorizontal);
-    SetPrototypeMethod(sConstructorTemplate, "isVertical", IsVertical);
-    SetPrototypeMethod(sConstructorTemplate, "hasOn", HasOn);
-    SetPrototypeMethod(sConstructorTemplate, "collinearHasOn", CollinearHasOn);
+    HandleScope scope(isolate);
+    Local<FunctionTemplate> constructorTemplate = sConstructorTemplate.Get(isolate);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isEqual", IsEqual);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "source", Source);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "point", Point);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "direction", Direction);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "toVector", ToVector);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "supportingLine", SupportingLine);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "opposite", Opposite);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isDegenerate", IsDegenerate);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isHorizontal", IsHorizontal);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "isVertical", IsVertical);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "hasOn", HasOn);
+    NODE_SET_PROTOTYPE_METHOD(constructorTemplate, "collinearHasOn", CollinearHasOn);
 }
 
 
-bool Ray2::ParseArg(Local<Value> arg, Ray_2 &receiver)
+bool Ray2::ParseArg(Isolate *isolate, Local<Value> arg, Ray_2 &receiver)
 {
-    if (sConstructorTemplate->HasInstance(arg)) {
+    HandleScope scope(isolate);
+
+    if (sConstructorTemplate.Get(isolate)->HasInstance(arg)) {
         receiver = ExtractWrapped(Local<Object>::Cast(arg));
         return true;
     }
@@ -42,32 +46,32 @@ bool Ray2::ParseArg(Local<Value> arg, Ray_2 &receiver)
 
         Point_2 p;
         Direction_2 d;
-        if (Point2::ParseArg(inits->Get(String::NewSymbol("p")), p) &&
-            Direction2::ParseArg(inits->Get(String::NewSymbol("d")), d))
+        if (Point2::ParseArg(isolate, inits->Get(SYMBOL(isolate, "p")), p) &&
+            Direction2::ParseArg(isolate, inits->Get(SYMBOL(isolate, "d")), d))
         {
             receiver = Ray_2(p, d);
             return true;
         }
 
         Point_2 q;
-        if (Point2::ParseArg(inits->Get(String::NewSymbol("p")), p) &&
-            Point2::ParseArg(inits->Get(String::NewSymbol("q")), q))
+        if (Point2::ParseArg(isolate, inits->Get(SYMBOL(isolate, "p")), p) &&
+            Point2::ParseArg(isolate, inits->Get(SYMBOL(isolate, "q")), q))
         {
             receiver = Ray_2(p, q);
             return true;
         }
 
         Line_2 l;
-        if (Point2::ParseArg(inits->Get(String::NewSymbol("p")), p) &&
-            Line2::ParseArg(inits->Get(String::NewSymbol("l")), l))
+        if (Point2::ParseArg(isolate, inits->Get(SYMBOL(isolate, "p")), p) &&
+            Line2::ParseArg(isolate, inits->Get(SYMBOL(isolate, "l")), l))
         {
             receiver = Ray_2(p, l);
             return true;
         }
 
         Vector_2 v;
-        if (Point2::ParseArg(inits->Get(String::NewSymbol("p")), p) &&
-            Vector2::ParseArg(inits->Get(String::NewSymbol("v")), v))
+        if (Point2::ParseArg(isolate, inits->Get(SYMBOL(isolate, "p")), p) &&
+            Vector2::ParseArg(isolate, inits->Get(SYMBOL(isolate, "v")), v))
         {
             receiver = Ray_2(p, v);
             return true;
@@ -79,175 +83,187 @@ bool Ray2::ParseArg(Local<Value> arg, Ray_2 &receiver)
 }
 
 
-Handle<Value> Ray2::ToPOD(const Ray_2 &ray, bool precise)
+Local<Value> Ray2::ToPOD(Isolate *isolate, const Ray_2 &ray, bool precise)
 {
-    HandleScope scope;
-    Local<Object> obj = Object::New();
-    obj->Set(String::NewSymbol("p"), Point2::ToPOD(ray.source(), precise));
-    obj->Set(String::NewSymbol("d"), Direction2::ToPOD(ray.direction(), precise));
-    return scope.Close(obj);
+    EscapableHandleScope scope(isolate);
+    Local<Object> obj = Object::New(isolate);
+    obj->Set(SYMBOL(isolate, "p"), Point2::ToPOD(isolate, ray.source(), precise));
+    obj->Set(SYMBOL(isolate, "d"), Direction2::ToPOD(isolate, ray.direction(), precise));
+    return scope.Escape(obj);
 }
 
 
-Handle<Value> Ray2::IsEqual(const v8::Arguments &args)
+void Ray2::IsEqual(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &thisRay = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Ray2::ParseArg, Ray_2, otherRay, args[0]);
-        return scope.Close(Boolean::New(thisRay == otherRay));
+        Ray_2 &thisRay = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Ray2::ParseArg, Ray_2, otherRay, info[0]);
+        info.GetReturnValue().Set(Boolean::New(isolate, thisRay == otherRay));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
-    }
-}
-
-
-Handle<Value> Ray2::Source(const v8::Arguments &args)
-{
-    HandleScope scope;
-    try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        return scope.Close(Point2::New(ray.source()));
-    }
-    catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::Point(const v8::Arguments &args)
+void Ray2::Source(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_ASSERT(args[0]->IsNumber())
-        return scope.Close(Point2::New(ray.point(args[0]->NumberValue())));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Point2::New(isolate, ray.source()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::Direction(const v8::Arguments &args)
+void Ray2::Point(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        return scope.Close(Direction2::New(ray.direction()));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_ASSERT(isolate, info[0]->IsNumber())
+        info.GetReturnValue().Set(Point2::New(isolate, ray.point(info[0]->NumberValue())));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::ToVector(const v8::Arguments &args)
+void Ray2::Direction(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        return scope.Close(Vector2::New(ray.to_vector()));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Direction2::New(isolate, ray.direction()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::SupportingLine(const v8::Arguments &args)
+void Ray2::ToVector(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        return scope.Close(Line2::New(ray.supporting_line()));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Vector2::New(isolate, ray.to_vector()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::Opposite(const v8::Arguments &args)
+void Ray2::SupportingLine(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        return scope.Close(Ray2::New(ray.opposite()));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Line2::New(isolate, ray.supporting_line()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::IsDegenerate(const v8::Arguments &args)
+void Ray2::Opposite(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(ray.is_degenerate()));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Ray2::New(isolate, ray.opposite()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::IsHorizontal(const v8::Arguments &args)
+void Ray2::IsDegenerate(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(ray.is_horizontal()));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, ray.is_degenerate()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::IsVertical(const v8::Arguments &args)
+void Ray2::IsHorizontal(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        return scope.Close(Boolean::New(ray.is_vertical()));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, ray.is_horizontal()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::HasOn(const v8::Arguments &args)
+void Ray2::IsVertical(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, point, args[0]);
-        return scope.Close(Boolean::New(ray.has_on(point)));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        info.GetReturnValue().Set(Boolean::New(isolate, ray.is_vertical()));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }
 
 
-Handle<Value> Ray2::CollinearHasOn(const v8::Arguments &args)
+void Ray2::HasOn(const FunctionCallbackInfo<Value> &info)
 {
-    HandleScope scope;
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
     try {
-        Ray_2 &ray = ExtractWrapped(args.This());
-        ARGS_ASSERT(args.Length() == 1);
-        ARGS_PARSE_LOCAL(Point2::ParseArg, Point_2, point, args[0]);
-        return scope.Close(Boolean::New(ray.collinear_has_on(point)));
+        Ray_2 &ray = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Point2::ParseArg, Point_2, point, info[0]);
+        info.GetReturnValue().Set(Boolean::New(isolate, ray.has_on(point)));
     }
     catch (const exception &e) {
-        return ThrowException(String::New(e.what()));
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
+    }
+}
+
+
+void Ray2::CollinearHasOn(const FunctionCallbackInfo<Value> &info)
+{
+    Isolate *isolate = info.GetIsolate();
+    HandleScope scope(isolate);
+    try {
+        Ray_2 &ray = ExtractWrapped(info.This());
+        ARGS_ASSERT(isolate, info.Length() == 1);
+        ARGS_PARSE_LOCAL(isolate, Point2::ParseArg, Point_2, point, info[0]);
+        info.GetReturnValue().Set(Boolean::New(isolate, ray.collinear_has_on(point)));
+    }
+    catch (const exception &e) {
+        isolate->ThrowException(String::NewFromUtf8(isolate, e.what()));
     }
 }

--- a/src/Ray2.h
+++ b/src/Ray2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Ray_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Ray_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Ray_2 &ray, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Ray_2 &ray, bool precise=true);
 
 private:
 
@@ -33,18 +33,18 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> IsEqual(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Source(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Point(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Direction(const v8::Arguments &args);
-    static v8::Handle<v8::Value> ToVector(const v8::Arguments &args);
-    static v8::Handle<v8::Value> SupportingLine(const v8::Arguments &args);
-    static v8::Handle<v8::Value> Opposite(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsDegenerate(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsHorizontal(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsVertical(const v8::Arguments &args);
-    static v8::Handle<v8::Value> HasOn(const v8::Arguments &args);
-    static v8::Handle<v8::Value> CollinearHasOn(const v8::Arguments &args);
+    static void IsEqual(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Source(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Point(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Direction(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void ToVector(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void SupportingLine(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void Opposite(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsDegenerate(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsHorizontal(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsVertical(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void HasOn(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void CollinearHasOn(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/Segment2.h
+++ b/src/Segment2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Segment_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Segment_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Segment_2 &segment, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Segment_2 &segment, bool precise=true);
 
 private:
 
@@ -33,8 +33,8 @@ private:
     //      the semantics and names of the wrapped CGAL class.
     //
 
-    static v8::Handle<v8::Value> IsHorizontal(const v8::Arguments &args);
-    static v8::Handle<v8::Value> IsVertical(const v8::Arguments &args);
+    static void IsHorizontal(const v8::FunctionCallbackInfo<v8::Value> &info);
+    static void IsVertical(const v8::FunctionCallbackInfo<v8::Value> &info);
 
 };
 

--- a/src/Vector2.h
+++ b/src/Vector2.h
@@ -16,15 +16,15 @@ public:
     // Add our function templates to the package exports, and return string to be used to name
     // the class and constructor in JS.  Called indirectly at module load time via the module
     // init function.
-    static void RegisterMethods();
+    static void RegisterMethods(v8::Isolate *isolate);
 
     // Attempt to parse a v8 argument into the CGAL object referred to by receiver.  Returns true
     // if parse was successful, false otherwise.
-    static bool ParseArg(v8::Local<v8::Value> arg, Vector_2 &receiver);
+    static bool ParseArg(v8::Isolate *isolate, v8::Local<v8::Value> arg, Vector_2 &receiver);
 
     // Convert a CGAL object of the wrapped class to a POD v8 object.  If precise is set to false,
     // will attempt to render in terms of doubles for coordinates, and may lose precision.
-    static v8::Handle<v8::Value> ToPOD(const Vector_2 &vector, bool precise=true);
+    static v8::Local<v8::Value> ToPOD(v8::Isolate *isolate, const Vector_2 &vector, bool precise=true);
 
 private:
 

--- a/src/cgal.cc
+++ b/src/cgal.cc
@@ -58,9 +58,7 @@ namespace {
 }
 
 
-NODE_MODULE(cgal, init);
-
-void init(Handle<Object> exports)
+void init(Local<Object> exports)
 {
     NODE_DEFINE_CONSTANT(exports, NEGATIVE);
     NODE_DEFINE_CONSTANT(exports, ZERO);
@@ -106,3 +104,8 @@ void init(Handle<Object> exports)
     Segment2::Init(exports);
     Vector2::Init(exports);
 }
+
+
+NODE_MODULE(cgal, init);
+
+

--- a/src/cgal.h
+++ b/src/cgal.h
@@ -3,9 +3,6 @@
 
 #include "node.h"
 
-NODE_MODULE_DECL(cgal);
-
-// Top level init function called at module load time.
-void init(v8::Handle<v8::Object> exports);
+void init(v8::Local<v8::Object> exports);
 
 #endif

--- a/src/cgal_args.h
+++ b/src/cgal_args.h
@@ -1,30 +1,39 @@
 #ifndef CGAL_ARGS_H
 #define CGAL_ARGS_H
 
-#define ARGS_ASSERT(ASSERTION)                                                                   \
-    if (!(ASSERTION)) {                                                                          \
-        return v8::ThrowException(v8::Exception::TypeError(v8::String::New("Wrong arguments"))); \
-    }                                                                                            \
+#define ARGS_ASSERT(ISOLATE, ASSERTION)                             \
+    if (!(ASSERTION)) {                                             \
+        (ISOLATE)->ThrowException(                                  \
+            v8::Exception::TypeError(                               \
+                v8::String::NewFromUtf8(ISOLATE, "Wrong arguments") \
+            )                                                       \
+        );                                                          \
+    }                                                               \
 
 
-#define ARGS_PARSE_LOCAL(PARSER, ARG_TYPE, RECEIVER, ARG) \
-    ARG_TYPE RECEIVER;                                    \
-    ARGS_ASSERT(PARSER(ARG, RECEIVER));                   \
+#define ARGS_PARSE_LOCAL(ISOLATE, PARSER, ARG_TYPE, RECEIVER, ARG) \
+    ARG_TYPE RECEIVER;                                             \
+    ARGS_ASSERT(ISOLATE, PARSER(ISOLATE, ARG, RECEIVER));          \
 
 
-#define ARGS_PARSE_LOCAL_SEQ(PARSER, ARG_TYPE, RECEIVER, ARG) \
-    ARG_TYPE RECEIVER;                                        \
-    ARGS_ASSERT(PARSER(ARG, std::back_inserter(RECEIVER)));   \
+#define ARGS_PARSE_LOCAL_SEQ(ISOLATE, PARSER, ARG_TYPE, RECEIVER, ARG)        \
+    ARG_TYPE RECEIVER;                                                        \
+    ARGS_ASSERT(ISOLATE, PARSER(ISOLATE, ARG, std::back_inserter(RECEIVER))); \
 
 
-#define ARGS_PARSE_NEW(PARSER, ARG_TYPE, RECEIVER, ARG)   \
-    ARG_TYPE *RECEIVER = new ARG_TYPE();                  \
-    ARGS_ASSERT(PARSER(ARG, *RECEIVER));                  \
+#define ARGS_PARSE_NEW(ISOLATE, PARSER, ARG_TYPE, RECEIVER, ARG) \
+    ARG_TYPE *RECEIVER = new ARG_TYPE();                         \
+    ARGS_ASSERT(ISOLATE, PARSER(ISOLATE, ARG, *RECEIVER));       \
 
 
-#define NOARGS_PARSE_NEW(PARSER, ARG_TYPE, RECEIVER)    \
-    ARG_TYPE *RECEIVER = new ARG_TYPE();                \
-    ARGS_ASSERT(PARSER(*RECEIVER));                     \
+#define NOARGS_PARSE_NEW(ISOLATE, PARSER, ARG_TYPE, RECEIVER) \
+    ARG_TYPE *RECEIVER = new ARG_TYPE();                      \
+    ARGS_ASSERT(ISOLATE, PARSER(ISOLATE, *RECEIVER));         \
 
+
+// Convenience macro for the deprecated v8::String::NewSymbol, beacuse
+// the recommended replacement incantation is super verbose...
+
+#define SYMBOL(ISOLATE, STRING) v8::String::NewFromUtf8(ISOLATE, STRING, v8::String::kInternalizedString)
 
 #endif // !defined(CGAL_ARGS_H)


### PR DESCRIPTION
Ran into Max in SF the other day, and he complained that the CGAL bindings were holding you guys to an older node release, so here ya go...  This works on OSX El Capitan and Linux with Node 5.0.0 and CGAL 4.7.  Probably works with slightly crustier versions as well if you don't want to go full bleeding edge.

This was a big pain in the ass!  Google has been merciless in making big, breaking changes to the V8 API (buttheads), and the node-ers have been not much better with their extension library API.  At least CGAL seems stable, ha :-)

The biggest changes here result from isolates being required strictly in many more places in the V8 API, and as well as changes to both the basic function signature for V8 callbacks and the associated return mechanism.  Also all the V8 string API points were changed incompatibly.  Srsly, guys...

A couple small things:
- ~~Owen had an empty-polygon seatbelt in Polygon2::IsSimple (CGAL segv's in this case).  The seatbelt doesn't seem to catch the empty case now, and I didn't have time to put gdb on it to find out why.  The API point works correctly otherwise.  I commented out the offending empty poly test for now.  I'll probably figure that out just out of curiosity, but wanted to put this up for you in the meantime 'coz I don't know when I'll next get back to it.~~ Found this, was missing return statement after search/replace, fixed, re-enabled test, and pushed.
- Node's constant-declaring API seems to have changed, and I'm not sure how to get the functionality for constants that was used in NefPolyhedron2 in the new world.  This won't matter for you since those wrappers didn't do anything yet besides the constants anyway.

Cheers!
